### PR TITLE
feat(mcp,console): script console refactor + 4 new MCP control tools (v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,19 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-10
+
+### Added
+
+- **MCP `rav_console_set_mode`** — Flip the bottom console between Event Console, JS REPL, or closed without re-opening the panel.
+- **MCP `rav_console_set_filter`** — Drive the existing on-screen filter toggles from any MCP client. JS mode supports `level` (`all`/`info`/`warning`/`error`); Event mode supports `sources` (subset of `native`/`riveUser`/`ui`/`mcp`); both modes support `search`. Auto-targets the active mode when `mode` is omitted.
+- **MCP `rav_console_clear`** — Clear the visible transcript of the active mode (or a specified mode) without closing the panel.
+- **Extended MCP `rav_console_open`** — Optional `mode`, `level`, `sources`, and `search` apply pre-configured filter state in the same call. Backwards compatible with no-argument invocations.
+- **MCP `rav_export_demo_visual`** — Orchestrates the Snippet & Export Controls dialog visually (open → selection → package/mode → click Export → save) for screen recordings or non-default control selections. Accepts `selection: "all" | "changed" | "none" | string[]`. The explicit-array form keys off a new `data-control-key` attribute on each tree checkbox.
+
 ### Changed
 
+- **Script console refactor** — Eruda configuration extracted into `console/eruda/configure-tool.js`; capture controller now owns Eruda logger attachment, type mapping (`input → command`, `output → result`, `verbose → debug`), and arg resolution. `summarizeConsoleExecution` extracted to `console/exec-outcome.js`. Presentation and ui-state controllers slimmed down accordingly. Test suite rewritten to match the new shape.
 - **Regression guardrails** — Documented the current prebuild protection stack around architecture drift, dependency boundaries, custom window chrome, and exported demo chrome so the `2.1.x` stabilization work has explicit gates instead of relying on ad hoc manual checks.
 
 ## [2.2.3] - 2026-04-05

--- a/README.md
+++ b/README.md
@@ -251,13 +251,13 @@ Open the RAV desktop app and enable the MCP bridge. The **MCP** chip in the runt
 | `rav_set_canvas_color` | Set background color or transparent |
 | `rav_set_canvas_size` | Set canvas sizing mode (`auto` or explicit pixels) and optional aspect lock |
 | `rav_export_demo` | Export standalone HTML demo |
-| `generate_web_instantiation_code` | Generate the canonical live web-instantiation snippet (`local` npm package or `cdn`) with `window.ravRive` helpers and current control values |
+| `generate_web_instantiation_code` | Generate the canonical live web-instantiation snippet (`local` npm package or `cdn`) with `window.ravRive` helpers and current control values. Preferred over hand-writing snippets from scratch. |
 | `rav_toggle_instantiation_controls_dialog` | Open/close the in-app Snippet & Export Controls dialog so a human can choose which controls are serialized |
 | `rav_configure_workspace` | Open/close sidebars, switch live source mode (`internal` / `editor`), and inject/remove the VM Explorer snippet idempotently |
 | `rav_get_sm_inputs` / `rav_set_sm_input` | State machine input access |
 | `rav_eval` | Evaluate JS in RAV's browser context (`Script Access` required) |
 | `rav_console_open` / `rav_console_close` | Toggle the JS console remotely |
-| `rav_console_read` / `rav_console_exec` | Read captured console output or run REPL code (`rav_console_exec` requires `Script Access`) |
+| `rav_console_read` / `rav_console_exec` | Read the JS console transcript or run REPL code (`rav_console_exec` requires `Script Access`). Transcript includes REPL input/result rows plus captured `console.*` output. |
 
 #### Editor and Export Semantics
 

--- a/architecture-budget.json
+++ b/architecture-budget.json
@@ -29,7 +29,9 @@
     "src-tauri/gen",
     "src/app/snippets/generated"
   ],
-  "grandfatheredMaxLines": {},
+  "grandfatheredMaxLines": {
+    "src/app/ui/script-console.js": 420
+  },
   "folderRoots": [
     "src/app",
     "src-tauri/src"

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -102,14 +102,14 @@ Once connected, Claude has access to all RAV tools. Try:
 | `rav_set_canvas_color` | Set background color |
 | `rav_set_canvas_size` | Set canvas sizing mode plus explicit pixel width/height and optional aspect lock |
 | `rav_export_demo` | Export standalone HTML demo |
-| `generate_web_instantiation_code` | Generate the canonical live web snippet for `local` or `cdn` usage, with `window.ravRive` helpers and current control values |
+| `generate_web_instantiation_code` | Generate the canonical live web snippet for `local` or `cdn` usage, with `window.ravRive` helpers and current control values. Preferred over hand-writing snippets from scratch. |
 | `rav_toggle_instantiation_controls_dialog` | Open/close the in-app Snippet & Export Controls dialog so a human can curate which controls are serialized |
 | `rav_configure_workspace` | Set left/right sidebar visibility, live source mode, and VM Explorer snippet presence in one idempotent call |
 | `rav_get_sm_inputs` | List state machine inputs with values |
 | `rav_set_sm_input` | Set state machine input value |
 | `rav_eval` | Evaluate JS in RAV's browser context (`Script Access` required) |
 | `rav_console_open` / `rav_console_close` | Toggle the JS console panel |
-| `rav_console_read` / `rav_console_exec` | Read captured console output or run REPL code (`rav_console_exec` requires `Script Access`) |
+| `rav_console_read` / `rav_console_exec` | Read the JS console transcript or run REPL code (`rav_console_exec` requires `Script Access`). Transcript includes REPL input/result rows plus captured `console.*` output. |
 
 ## Live Instantiation Semantics
 

--- a/mcp-server/instructions.js
+++ b/mcp-server/instructions.js
@@ -30,6 +30,8 @@ You are connected to a running instance of Rive Animation Viewer (RAV), a deskto
 - \`editor\` means the running animation is using the last applied editor code, not necessarily the current unsaved draft in the panel.
 - \`autoBind: true\` is required for ViewModel access.
 - \`stateMachines: "Name"\` must be set to activate a state machine.
+- If the user asks for a working instantiation snippet, prefer **generate_web_instantiation_code** first instead of hand-writing one from scratch.
+- If you do need to edit the live config, call **rav_get_editor_code** first and modify the returned object surgically. Do not invent placeholder globals like `FILE`, `FILE_PATH`, or custom file tokens.
 - Use **rav_set_editor_code** then **rav_apply_code** to change configuration and reload.
 - **rav_status** returns the live instantiation source and whether the editor has unapplied draft changes.
 - **generate_web_instantiation_code** returns the canonical copy-paste snippet for the live mode currently running in RAV.
@@ -44,11 +46,16 @@ You are connected to a running instance of Rive Animation Viewer (RAV), a deskto
 ## Tips
 - If rav_get_vm_tree returns empty but you suspect there's a ViewModel, ensure the editor config includes \`autoBind: true\` and \`stateMachines\` is set, then call rav_apply_code.
 - Use **rav_eval** for anything not covered by the dedicated tools — it runs JS in the browser context with access to \`window.riveInst\` and all globals.
+- The stable live instance is \`window.riveInst\`. Do not assume a local callback variable like \`rive\` will remain authoritative after reloads.
 - **rav_get_event_log** shows runtime events, user events, UI events, and MCP events — useful for debugging what happened.
-- **rav_console_open** / **rav_console_close** toggle the JS console panel.
-- **rav_console_read** returns captured console.* output (all calls since app start).
-- **rav_console_exec** evaluates code in the REPL with output shown in the console panel.
+- **rav_console_open** / **rav_console_close** toggle the JS console panel. \`rav_console_open\` accepts optional \`mode\` (events/js), \`level\`, \`sources\`, and \`search\` to apply a filter on open.
+- **rav_console_set_mode** flips the panel between Events and JS modes (or \`closed\`) without re-opening.
+- **rav_console_set_filter** mirrors the existing on-screen filter toggles: \`level\` (all/info/warning/error) for JS mode, \`sources\` subset of (native/riveUser/ui/mcp) for Events mode, plus optional \`search\` substring.
+- **rav_console_clear** clears the visible transcript of the active mode (or a specified mode) without closing the panel.
+- **rav_console_read** returns the JS console transcript, including REPL input/result rows and captured \`console.*\` output.
+- **rav_console_exec** evaluates code in the REPL with output shown in the console panel. Use \`rav_console_read\` to verify what actually happened instead of assuming execution succeeded.
 - **rav_export_demo** creates a self-contained HTML file with the current animation, runtime, and settings baked in.
+- **rav_export_demo_visual** orchestrates the Snippet & Export Controls dialog visibly (open → selection → package/mode → Export → save) for screen recordings or non-default selections.
 - **rav_configure_workspace** sets left/right sidebar visibility, live editor/internal mode, and VM Explorer snippet state in one idempotent call.
 - **generate_web_instantiation_code** is the preferred way to get a web snippet. It bakes in the current runtime package, artboard/playback selection, layout fit/alignment, background mode, the active instantiation source, and the currently selected bound control values.
 - **rav_toggle_instantiation_controls_dialog** opens the in-app control-selection dialog so a human can choose exactly which values will be serialized into snippets and exported demos.

--- a/mcp-server/tools/editor-tools.js
+++ b/mcp-server/tools/editor-tools.js
@@ -9,7 +9,7 @@ export const EDITOR_TOOLS = [
     name: 'rav_set_editor_code',
     description:
       'Replace the code in the RAV script editor. This does NOT reload the ' +
-      'animation — call rav_apply_code afterwards to apply changes.',
+      'animation — call rav_get_editor_code first, preserve the current structure, avoid fake FILE placeholders, then call rav_apply_code.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -50,12 +50,51 @@ export const EDITOR_TOOLS = [
     },
   },
   {
+    name: 'rav_export_demo_visual',
+    description:
+      'Orchestrate the Snippet & Export Controls dialog visually: open the dialog, apply the control selection, set package source and snippet mode, click Export, and write the demo to output_path. ' +
+      'Use this when the export needs to be visible (screen recordings) or when a non-default control selection is required. For pure programmatic export, use rav_export_demo.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        output_path: {
+          type: 'string',
+          description: 'Absolute path where the exported HTML demo will be saved.',
+        },
+        selection: {
+          oneOf: [
+            { type: 'string', enum: ['all', 'changed', 'none'] },
+            { type: 'array', items: { type: 'string' }, description: 'Explicit list of control snapshot keys to enable.' },
+          ],
+          description:
+            "How to populate the dialog's control selection. 'all' clicks SELECT ALL, 'changed' clicks CHANGED ONLY, 'none' clicks CLEAR, or pass an explicit array of control keys.",
+        },
+        package_source: {
+          type: 'string',
+          enum: ['cdn', 'local'],
+          description: 'Optional. Sets the package source select. Default: leave as-is.',
+        },
+        snippet_mode: {
+          type: 'string',
+          enum: ['compact', 'scaffold'],
+          description: 'Optional. Sets the snippet mode select. Default: leave as-is.',
+        },
+        step_delay_ms: {
+          type: 'number',
+          description: 'Milliseconds between visible steps so a recording captures each. Default: 250.',
+        },
+      },
+      required: ['output_path'],
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'generate_web_instantiation_code',
     description:
       'Generate a copy-paste-ready web instantiation snippet for the animation currently loaded in RAV. ' +
       'The snippet mirrors the live source mode that is actually running in RAV: either internal wiring ' +
       'or the last applied editor code. Supports either CDN or local npm package usage, restores the current ' +
-      'ViewModel/state-machine values on load, and exposes helper controls on window.ravRive.',
+      'ViewModel/state-machine values on load, and exposes helper controls on window.ravRive. This is the preferred way to provide a working runtime-control snippet.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -146,8 +185,22 @@ export const EDITOR_TOOLS = [
   },
   {
     name: 'rav_console_open',
-    description: 'Open the JavaScript console panel (switches from Event Console to JS Console mode).',
-    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    description:
+      'Open the bottom console panel. Defaults to JS mode. Optional `mode`, `level`, `sources`, and `search` apply pre-configured filter state on open.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['events', 'js'], description: 'Mode to activate on open. Default: js.' },
+        level: { type: 'string', enum: ['all', 'info', 'warning', 'error'], description: 'JS console level filter (only applies when mode is js).' },
+        sources: {
+          type: 'array',
+          items: { type: 'string', enum: ['native', 'riveUser', 'ui', 'mcp'] },
+          description: 'Event console source toggles to enable (only applies when mode is events). Sources omitted are hidden.',
+        },
+        search: { type: 'string', description: 'Substring filter applied to console entries.' },
+      },
+      additionalProperties: false,
+    },
   },
   {
     name: 'rav_console_close',
@@ -155,10 +208,55 @@ export const EDITOR_TOOLS = [
     inputSchema: { type: 'object', properties: {}, additionalProperties: false },
   },
   {
+    name: 'rav_console_set_mode',
+    description: "Set the bottom console panel mode to Event Console ('events'), JS REPL ('js'), or close it ('closed'). Opens the panel first if needed.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['events', 'js', 'closed'], description: 'Console mode to activate.' },
+      },
+      required: ['mode'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'rav_console_set_filter',
+    description:
+      'Apply filters to the rendered console transcript. Mirrors the existing on-screen filter toggles. ' +
+      'JS mode supports `level` (all/info/warning/error). Events mode supports `sources` (subset of native/riveUser/ui/mcp — sources omitted from the array are hidden). ' +
+      'Both modes support `search`. Targets the currently active mode if `mode` is omitted.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['events', 'js'], description: 'Optional — apply to a specific mode. Defaults to the currently active mode.' },
+        level: { type: 'string', enum: ['all', 'info', 'warning', 'error'], description: 'JS console level filter.' },
+        sources: {
+          type: 'array',
+          items: { type: 'string', enum: ['native', 'riveUser', 'ui', 'mcp'] },
+          description: 'Event console source toggles to enable. Sources omitted from the array are hidden.',
+        },
+        search: { type: 'string', description: 'Substring filter applied to entry text. Empty string clears the search filter.' },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'rav_console_clear',
+    description: 'Clear the visible transcript of the bottom console panel (Events or JS mode). Does not close the panel.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        mode: { type: 'string', enum: ['events', 'js'], description: "Optional — clear a specific mode's transcript. Defaults to the currently active mode." },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
     name: 'rav_console_read',
     description:
-      'Read captured console output (console.log/warn/error/info/debug). ' +
-      'Returns the most recent entries with method, timestamp, and args.',
+      'Read the JS console transcript, including REPL input/result rows and ' +
+      'captured console.log/warn/error/info/debug output. Returns the most ' +
+      'recent entries with method, timestamp, and args.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -174,8 +272,9 @@ export const EDITOR_TOOLS = [
     name: 'rav_console_exec',
     description:
       'Execute JavaScript in the REPL console. The code is evaluated in the ' +
-      'browser context with output displayed in the console panel. ' +
-      'Opens the console automatically if not already open.',
+      'browser context with output displayed in the console panel. Use ' +
+      'rav_console_read to inspect the resulting transcript, including REPL ' +
+      'input/result rows. Opens the console automatically if not already open.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rive-animation-viewer",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Desktop and web viewer for .riv files with ViewModel controls, artboard/animation switching, script editor, event console, standalone export, and MCP remote control",
   "main": "index.html",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "2.2.3"
+version = "2.3.0"
 description = "A Tauri App"
 authors = ["IVG Design"]
 license = "MIT"

--- a/src-tauri/src/bin/rav-mcp/support/instructions.rs
+++ b/src-tauri/src/bin/rav-mcp/support/instructions.rs
@@ -29,6 +29,8 @@ You are connected to a running instance of Rive Animation Viewer (RAV), a deskto
 - `editor` means the running animation is using the last applied editor code, not necessarily the current unsaved draft in the panel.
 - `autoBind: true` is required for ViewModel access.
 - `stateMachines: "Name"` must be set to activate a state machine.
+- If the user asks for a working instantiation snippet, prefer **generate_web_instantiation_code** first instead of hand-writing one from scratch.
+- If you do need to edit the live config, call **rav_get_editor_code** first and modify the returned object surgically. Do not invent placeholder globals like `FILE`, `FILE_PATH`, or custom file tokens.
 - Use **rav_set_editor_code** then **rav_apply_code** to change configuration and reload.
 - **rav_status** returns the live instantiation source and whether the editor has unapplied draft changes.
 - **generate_web_instantiation_code** returns the canonical copy-paste snippet for the live mode currently running in RAV.
@@ -43,11 +45,16 @@ You are connected to a running instance of Rive Animation Viewer (RAV), a deskto
 ## Tips
 - If rav_get_vm_tree returns empty but you suspect there's a ViewModel, ensure the editor config includes `autoBind: true` and `stateMachines` is set, then call rav_apply_code.
 - Use **rav_eval** for anything not covered by the dedicated tools — it runs JS in the browser context with access to `window.riveInst` and all globals.
+- The stable live instance is `window.riveInst`. Do not assume a local callback variable like `rive` will remain authoritative after reloads.
 - **rav_get_event_log** shows runtime events, user events, UI events, and MCP events — useful for debugging what happened.
-- **rav_console_open** / **rav_console_close** toggle the JS console panel.
-- **rav_console_read** returns captured console.* output (all calls since app start).
-- **rav_console_exec** evaluates code in the REPL with output shown in the console panel.
+- **rav_console_open** / **rav_console_close** toggle the JS console panel. `rav_console_open` accepts optional `mode` (events/js), `level`, `sources`, and `search` to apply a filter on open.
+- **rav_console_set_mode** flips the panel between Events and JS modes (or `closed`) without re-opening.
+- **rav_console_set_filter** mirrors the existing on-screen filter toggles: `level` (all/info/warning/error) for JS mode, `sources` subset of (native/riveUser/ui/mcp) for Events mode, plus optional `search` substring.
+- **rav_console_clear** clears the visible transcript of the active mode (or a specified mode) without closing the panel.
+- **rav_console_read** returns the JS console transcript, including REPL input/result rows and captured `console.*` output.
+- **rav_console_exec** evaluates code in the REPL with output shown in the console panel. Use `rav_console_read` to verify what actually happened instead of assuming execution succeeded.
 - **rav_export_demo** creates a self-contained HTML file with the current animation, runtime, and settings baked in.
+- **rav_export_demo_visual** orchestrates the Snippet & Export Controls dialog visibly (open → selection → package/mode → Export → save) for screen recordings or non-default selections.
 - **rav_configure_workspace** sets left/right sidebar visibility, live editor/internal mode, and VM Explorer snippet state in one idempotent call.
 - **generate_web_instantiation_code** is the preferred way to get a web snippet. It bakes in the current runtime package, artboard/playback selection, layout fit/alignment, background mode, the active instantiation source, and the currently selected bound control values.
 - **rav_toggle_instantiation_controls_dialog** opens the in-app control-selection dialog so a human can choose exactly which values will be serialized into snippets and exported demos."#;

--- a/src-tauri/src/bin/rav-mcp/tool_registry.rs
+++ b/src-tauri/src/bin/rav-mcp/tool_registry.rs
@@ -203,8 +203,30 @@ pub fn tools_list() -> Value {
             }
         },
         {
+            "name": "rav_export_demo_visual",
+            "description": "Orchestrate the Snippet & Export Controls dialog visually: open the dialog, apply the control selection, set package source and snippet mode, click Export, and write the demo to `output_path`. Use this when the export needs to be visible (e.g. screen recording) or when a non-default control selection is required. For pure programmatic export, use `rav_export_demo`.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "output_path": { "type": "string", "description": "Absolute path where the exported HTML demo will be saved." },
+                    "selection": {
+                        "oneOf": [
+                            { "type": "string", "enum": ["all", "changed", "none"] },
+                            { "type": "array", "items": { "type": "string" }, "description": "Explicit list of control snapshot keys to enable." }
+                        ],
+                        "description": "How to populate the dialog's control selection. 'all' clicks SELECT ALL, 'changed' clicks CHANGED ONLY, 'none' clicks CLEAR, or pass an explicit array of control keys."
+                    },
+                    "package_source": { "type": "string", "enum": ["cdn", "local"], "description": "Optional. Sets the package source select. Default: leave as-is." },
+                    "snippet_mode": { "type": "string", "enum": ["compact", "scaffold"], "description": "Optional. Sets the snippet mode select. Default: leave as-is." },
+                    "step_delay_ms": { "type": "number", "description": "Milliseconds between visible steps so a recording captures each. Default: 250." }
+                },
+                "required": ["output_path"],
+                "additionalProperties": false
+            }
+        },
+        {
             "name": "generate_web_instantiation_code",
-            "description": "Generate a copy-paste-ready web instantiation snippet for the animation currently loaded in RAV. The snippet mirrors the live source mode that is actually running in RAV: either internal wiring or the last applied editor code. Supports either CDN or local npm package usage, restores the current ViewModel/state-machine values on load, and exposes helper controls on window.ravRive.",
+            "description": "Generate the preferred working web instantiation snippet for the animation currently loaded in RAV. Use this instead of hand-writing editor snippets when you need a reliable runtime-control example. The snippet mirrors the live source mode that is actually running in RAV: either internal wiring or the last applied editor code. Supports either CDN or local npm package usage, restores the current ViewModel/state-machine values on load, and exposes helper controls on window.ravRive.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -271,8 +293,21 @@ pub fn tools_list() -> Value {
         },
         {
             "name": "rav_console_open",
-            "description": "Open the JavaScript console panel (switches from Event Console to JS Console mode).",
-            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+            "description": "Open the bottom console panel. Defaults to JS mode. Optional `mode`, `level`, `sources`, and `search` apply pre-configured filter state on open.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": { "type": "string", "enum": ["events", "js"], "description": "Mode to activate on open. Default: js." },
+                    "level": { "type": "string", "enum": ["all", "info", "warning", "error"], "description": "JS console level filter (only applies when mode is js)." },
+                    "sources": {
+                        "type": "array",
+                        "items": { "type": "string", "enum": ["native", "riveUser", "ui", "mcp"] },
+                        "description": "Event console source toggles to enable (only applies when mode is events). Sources not listed are hidden."
+                    },
+                    "search": { "type": "string", "description": "Substring filter applied to console entries." }
+                },
+                "additionalProperties": false
+            }
         },
         {
             "name": "rav_console_close",
@@ -280,8 +315,49 @@ pub fn tools_list() -> Value {
             "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
         },
         {
+            "name": "rav_console_set_mode",
+            "description": "Set the bottom console panel mode to Event Console (`events`), JS REPL (`js`), or close it (`closed`). Opens the panel first if needed.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": { "type": "string", "enum": ["events", "js", "closed"], "description": "Console mode to activate." }
+                },
+                "required": ["mode"],
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "rav_console_set_filter",
+            "description": "Apply filters to the rendered console transcript. Mirrors the existing on-screen filter toggles. JS mode supports `level` (all/info/warning/error). Events mode supports `sources` (subset of native/riveUser/ui/mcp — sources not listed are hidden). Both modes support `search`. Targets the currently active mode if `mode` is omitted.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": { "type": "string", "enum": ["events", "js"], "description": "Optional — apply to a specific mode. Defaults to the currently active mode." },
+                    "level": { "type": "string", "enum": ["all", "info", "warning", "error"], "description": "JS console level filter." },
+                    "sources": {
+                        "type": "array",
+                        "items": { "type": "string", "enum": ["native", "riveUser", "ui", "mcp"] },
+                        "description": "Event console source toggles to enable. Sources omitted from the array are hidden."
+                    },
+                    "search": { "type": "string", "description": "Substring filter applied to entry text. Empty string clears the search filter." }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "rav_console_clear",
+            "description": "Clear the visible transcript of the bottom console panel (Events or JS mode). Does not close the panel.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "mode": { "type": "string", "enum": ["events", "js"], "description": "Optional — clear a specific mode's transcript. Defaults to the currently active mode." }
+                },
+                "additionalProperties": false
+            }
+        },
+        {
             "name": "rav_console_read",
-            "description": "Read captured console output (console.log/warn/error/info/debug). Returns the most recent entries with method, timestamp, and args.",
+            "description": "Read the JS console transcript, including REPL input/result rows and captured console.log/warn/error/info/debug output. Returns recent entries in transcript order with method, timestamp, and args.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -292,7 +368,7 @@ pub fn tools_list() -> Value {
         },
         {
             "name": "rav_console_exec",
-            "description": "Execute JavaScript in the REPL console. The code is evaluated in the browser context with output displayed in the console panel. Opens the console automatically if not already open.",
+            "description": "Execute JavaScript in the REPL console. The code is evaluated in the browser context with output displayed in the console panel. Use rav_console_read to inspect the resulting transcript, including REPL input/result rows. Opens the console automatically if not already open.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rive Animation Viewer",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "identifier": "app.rive.animation.viewer",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/app/bootstrap/stacks/controller-stack.js
+++ b/src/app/bootstrap/stacks/controller-stack.js
@@ -169,6 +169,7 @@ export function createControllerStack({
             cleanupInstance,
             consoleModeController: uiStack.consoleModeController,
             createDemoBundle,
+            eventLogController: uiStack.eventLogController,
             ensureEditorReady: uiStack.ensureEditorReady,
             ensureRuntime,
             ensureTauriBridge,

--- a/src/app/bootstrap/stacks/platform-stack.js
+++ b/src/app/bootstrap/stacks/platform-stack.js
@@ -19,6 +19,7 @@ export function createPlatformStack({
         ensureEditorReady,
         ensureRuntime,
         ensureTauriBridge,
+        eventLogController,
         getArtboardStateSnapshot,
         getChangedVmControlSnapshot,
         getCurrentFileBuffer,
@@ -225,6 +226,11 @@ export function createPlatformStack({
                 await consoleModeController.setConsoleMode('js');
                 return { open: true };
             },
+            setConsoleMode: async (mode) => consoleModeController.setConsoleMode(mode),
+            setScriptConsoleFilter: (filter) => scriptConsoleController.setFilter(filter),
+            setEventLogFilter: (filter) => eventLogController.setFilter(filter),
+            clearScriptConsole: () => scriptConsoleController.clear(),
+            clearEventLog: () => eventLogController.clearLog(),
             pause,
             play,
             refreshVmInputControls,

--- a/src/app/platform/global-bindings.js
+++ b/src/app/platform/global-bindings.js
@@ -50,6 +50,11 @@ export function createGlobalBindingsController({
         execScriptConsole = async () => ({ ok: false }),
         isScriptConsoleOpen = () => false,
         openScriptConsole = async () => ({ open: true }),
+        setConsoleMode = async () => {},
+        setScriptConsoleFilter = () => ({}),
+        setEventLogFilter = () => ({}),
+        clearScriptConsole = () => {},
+        clearEventLog = () => {},
         pause = () => {},
         play = () => {},
         refreshVmInputControls = () => {},
@@ -101,6 +106,34 @@ export function createGlobalBindingsController({
         windowRef._mcpConsoleIsOpen = () => isScriptConsoleOpen();
         windowRef._mcpConsoleRead = (limit) => getScriptConsoleEntries(limit);
         windowRef._mcpConsoleExec = async (code) => execScriptConsole(code);
+        windowRef._mcpSetConsoleMode = async (mode) => {
+            const normalized = mode === 'js' ? 'js' : mode === 'events' ? 'events' : mode === 'closed' ? 'closed' : null;
+            if (!normalized) throw new Error("mode must be 'events', 'js', or 'closed'");
+            await setConsoleMode(normalized);
+            return { ok: true, mode: normalized, jsOpen: isScriptConsoleOpen() };
+        };
+        windowRef._mcpSetConsoleFilter = ({ mode, level, sources, search } = {}) => {
+            const target = mode === 'events' || mode === 'js'
+                ? mode
+                : (isScriptConsoleOpen() ? 'js' : 'events');
+            if (target === 'js') {
+                const result = setScriptConsoleFilter({ level, search });
+                return { ok: true, mode: 'js', ...result };
+            }
+            const result = setEventLogFilter({ sources, search });
+            return { ok: true, mode: 'events', ...result };
+        };
+        windowRef._mcpConsoleClear = (mode) => {
+            const target = mode === 'events' || mode === 'js'
+                ? mode
+                : (isScriptConsoleOpen() ? 'js' : 'events');
+            if (target === 'js') {
+                clearScriptConsole();
+            } else {
+                clearEventLog();
+            }
+            return { ok: true, mode: target };
+        };
         windowRef._mcpGetEditorCode = async () => {
             await ensureEditorReady();
             return getEditorCode();

--- a/src/app/platform/mcp/command-handlers.js
+++ b/src/app/platform/mcp/command-handlers.js
@@ -13,6 +13,6 @@ export function createMcpCommandHandlers({
         ...createStatusPlaybackCommands({ buildViewModelSnapshot, documentRef, windowRef }),
         ...createViewModelCommands({ buildViewModelSnapshot, windowRef }),
         ...createEditorConsoleCommands({ assertMcpScriptAccess, documentRef, windowRef }),
-        ...createExportWorkspaceCommands({ windowRef }),
+        ...createExportWorkspaceCommands({ documentRef, windowRef }),
     };
 }

--- a/src/app/platform/mcp/commands/editor-console.js
+++ b/src/app/platform/mcp/commands/editor-console.js
@@ -118,14 +118,48 @@ export function createEditorConsoleCommands({
             }
         },
 
-        async rav_console_open() {
+        async rav_console_open({ mode = 'js', level, sources, search } = {}) {
             if (typeof windowRef._mcpConsoleOpen !== 'function') throw new Error('Console not available');
-            return windowRef._mcpConsoleOpen();
+            const normalizedMode = mode === 'events' ? 'events' : 'js';
+            if (typeof windowRef._mcpSetConsoleMode === 'function') {
+                await windowRef._mcpSetConsoleMode(normalizedMode);
+            } else {
+                await windowRef._mcpConsoleOpen();
+            }
+            if ((level !== undefined || sources !== undefined || search !== undefined)
+                && typeof windowRef._mcpSetConsoleFilter === 'function') {
+                windowRef._mcpSetConsoleFilter({ mode: normalizedMode, level, sources, search });
+            }
+            return { ok: true, open: true, mode: normalizedMode };
         },
 
         async rav_console_close() {
             if (typeof windowRef._mcpConsoleClose !== 'function') throw new Error('Console not available');
             return windowRef._mcpConsoleClose();
+        },
+
+        async rav_console_set_mode({ mode } = {}) {
+            if (mode !== 'events' && mode !== 'js' && mode !== 'closed') {
+                throw new Error("mode must be 'events', 'js', or 'closed'");
+            }
+            if (typeof windowRef._mcpSetConsoleMode !== 'function') {
+                throw new Error('Console mode binding not available');
+            }
+            return windowRef._mcpSetConsoleMode(mode);
+        },
+
+        async rav_console_set_filter({ mode, level, sources, search } = {}) {
+            if (typeof windowRef._mcpSetConsoleFilter !== 'function') {
+                throw new Error('Console filter binding not available');
+            }
+            return windowRef._mcpSetConsoleFilter({ mode, level, sources, search });
+        },
+
+        async rav_console_clear({ mode } = {}) {
+            if (typeof windowRef._mcpConsoleClear !== 'function') {
+                throw new Error('Console clear binding not available');
+            }
+            return windowRef._mcpConsoleClear(mode);
         },
 
         async rav_console_read({ limit = 50 } = {}) {

--- a/src/app/platform/mcp/commands/export-workspace.js
+++ b/src/app/platform/mcp/commands/export-workspace.js
@@ -1,6 +1,9 @@
 export function createExportWorkspaceCommands({
+    documentRef = globalThis.document,
     windowRef = globalThis.window,
 } = {}) {
+    const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, Math.max(0, ms || 0)));
+
     return {
         async rav_export_demo({ output_path } = {}) {
             if (output_path && typeof windowRef._mcpExportDemoToPath === 'function') {
@@ -25,6 +28,74 @@ export function createExportWorkspaceCommands({
                 throw new Error('Instantiation controls dialog not available');
             }
             return windowRef._mcpToggleInstantiationControlsDialog(action);
+        },
+
+        async rav_export_demo_visual({
+            output_path,
+            selection,
+            package_source,
+            snippet_mode,
+            step_delay_ms = 250,
+        } = {}) {
+            if (!output_path) throw new Error('output_path is required');
+            if (typeof windowRef._mcpToggleInstantiationControlsDialog !== 'function') {
+                throw new Error('Instantiation controls dialog binding not available');
+            }
+            if (typeof windowRef._mcpExportDemoToPath !== 'function') {
+                throw new Error('Export-to-path binding not available');
+            }
+
+            await windowRef._mcpToggleInstantiationControlsDialog('open');
+            await sleep(step_delay_ms);
+
+            if (selection === 'all') {
+                documentRef.getElementById('instantiation-preset-all-btn')?.click();
+            } else if (selection === 'changed') {
+                documentRef.getElementById('instantiation-preset-changed-btn')?.click();
+            } else if (selection === 'none') {
+                documentRef.getElementById('instantiation-preset-none-btn')?.click();
+            } else if (Array.isArray(selection)) {
+                const tree = documentRef.getElementById('instantiation-controls-tree');
+                if (!tree) throw new Error('Controls tree not in DOM');
+                const wanted = new Set(selection);
+                const checkboxes = tree.querySelectorAll('input[type="checkbox"][data-control-key]');
+                checkboxes.forEach((checkbox) => {
+                    const key = checkbox.getAttribute('data-control-key');
+                    const shouldBeChecked = wanted.has(key);
+                    if (checkbox.checked !== shouldBeChecked) checkbox.click();
+                });
+            }
+            if (selection !== undefined) await sleep(step_delay_ms);
+
+            if (package_source) {
+                const select = documentRef.getElementById('instantiation-package-source-select');
+                if (select) {
+                    select.value = package_source;
+                    select.dispatchEvent(new Event('change', { bubbles: true }));
+                    await sleep(step_delay_ms);
+                }
+            }
+
+            if (snippet_mode) {
+                const select = documentRef.getElementById('instantiation-snippet-mode-select');
+                if (select) {
+                    select.value = snippet_mode;
+                    select.dispatchEvent(new Event('change', { bubbles: true }));
+                    await sleep(step_delay_ms);
+                }
+            }
+
+            const exportBtn = documentRef.getElementById('instantiation-dialog-export-btn');
+            if (exportBtn) {
+                exportBtn.classList.add('is-pressing');
+                await sleep(150);
+                exportBtn.classList.remove('is-pressing');
+            }
+
+            const savedPath = await windowRef._mcpExportDemoToPath(output_path);
+            await windowRef._mcpToggleInstantiationControlsDialog('close');
+
+            return { ok: true, path: savedPath };
         },
 
         async rav_configure_workspace({

--- a/src/app/snippets/generated/editor-defaults.generated.js
+++ b/src/app/snippets/generated/editor-defaults.generated.js
@@ -2,7 +2,7 @@
 export const DEFAULT_EDITOR_CODE = `// Rive instantiation config — riveInst is the global instance
 // Uncomment any property to override defaults
 
-({
+{
   autoplay: true,
   autoBind: true,
 
@@ -27,7 +27,7 @@ export const DEFAULT_EDITOR_CODE = `// Rive instantiation config — riveInst is
   // onPause: () => { console.log("pause"); },
   // onStop: () => { console.log("stop"); },
   // onLoop: (event) => { console.log("loop:", event); },
-})`;
+}`;
 export const DEFAULT_EDITOR_ONLOAD_BLOCK = `onLoad: () => {
     riveInst.resizeDrawingSurfaceToCanvas();
     window.refreshVmInputControls?.();

--- a/src/app/snippets/source/default-editor.js
+++ b/src/app/snippets/source/default-editor.js
@@ -1,7 +1,7 @@
 // Rive instantiation config — riveInst is the global instance
 // Uncomment any property to override defaults
 
-({
+{
   autoplay: true,
   autoBind: true,
 
@@ -26,4 +26,4 @@
   // onPause: () => { console.log("pause"); },
   // onStop: () => { console.log("stop"); },
   // onLoop: (event) => { console.log("loop:", event); },
-})
+}

--- a/src/app/ui/code-editor.js
+++ b/src/app/ui/code-editor.js
@@ -6,6 +6,7 @@ import {
     evaluateEditorConfig,
     extractBraceBlock,
     hasVmExplorerSnippet,
+    normalizeEditorDisplayCode,
     replaceOnLoadBlock,
 } from './editor/editor-code-utils.js';
 import { setVmExplorerSnippetEnabledOnEditor } from './editor/vm-explorer-toggle.js';
@@ -79,9 +80,10 @@ export function createCodeEditorController({
         if (!editorView) {
             return false;
         }
+        const normalizedCode = normalizeEditorDisplayCode(code);
         isAutoFilling = true;
         editorView.dispatch({
-            changes: { from: 0, to: editorView.state.doc.length, insert: code },
+            changes: { from: 0, to: editorView.state.doc.length, insert: normalizedCode },
         });
         isAutoFilling = false;
         updateLiveModeChip();

--- a/src/app/ui/console/capture-controller.js
+++ b/src/app/ui/console/capture-controller.js
@@ -1,3 +1,38 @@
+function mapErudaLogType(type) {
+    if (type === 'input') {
+        return 'command';
+    }
+    if (type === 'output') {
+        return 'result';
+    }
+    if (type === 'warning') {
+        return 'warn';
+    }
+    if (type === 'verbose') {
+        return 'debug';
+    }
+    if (type === 'dir') {
+        return 'dir';
+    }
+    if (type === 'error') {
+        return 'error';
+    }
+    if (type === 'info') {
+        return 'info';
+    }
+    return 'log';
+}
+
+function resolveErudaLogArgs(log) {
+    if (Array.isArray(log?.args) && log.args.length) {
+        return log.args;
+    }
+    if (log?.header !== undefined && log?.header !== null) {
+        return [log.header];
+    }
+    return [];
+}
+
 export function createConsoleCaptureController({
     formatEntryMessage,
     getConsoleTool,
@@ -7,6 +42,7 @@ export function createConsoleCaptureController({
     maxErudaLogs,
     mirrorEntryToEruda,
     normalizeSerializable,
+    onErudaInsert = () => {},
     renderConsoleEntries,
     scrollConsoleToLatest,
     setTimeoutFn = globalThis.setTimeout?.bind(globalThis),
@@ -26,6 +62,37 @@ export function createConsoleCaptureController({
         }
 
         renderConsoleEntries();
+    }
+
+    function attachErudaLogger(logger) {
+        if (!logger || typeof logger.on !== 'function' || state.erudaLogger === logger) {
+            return;
+        }
+        detachErudaLogger();
+        state.erudaLogger = logger;
+        state.erudaInsertHandler = (log) => {
+            if (state.erudaSyncingCapturedEntries) {
+                return;
+            }
+            appendCapturedEntry({
+                method: mapErudaLogType(log?.type),
+                args: resolveErudaLogArgs(log),
+                timestamp: Date.now(),
+            }, { mirrorToEruda: false });
+            onErudaInsert(log);
+        };
+        logger.on('insert', state.erudaInsertHandler);
+    }
+
+    function detachErudaLogger() {
+        if (!state.erudaLogger || !state.erudaInsertHandler) {
+            state.erudaLogger = null;
+            state.erudaInsertHandler = null;
+            return;
+        }
+        state.erudaLogger.off?.('insert', state.erudaInsertHandler);
+        state.erudaLogger = null;
+        state.erudaInsertHandler = null;
     }
 
     function installCapture() {
@@ -84,9 +151,7 @@ export function createConsoleCaptureController({
                 }
                 const haystack = `${entry.method} ${formatEntryMessage(entry)}`.toLowerCase();
                 return haystack.includes(searchNeedle);
-            })
-            .slice()
-            .reverse();
+            });
     }
 
     function clearConsole() {
@@ -104,7 +169,6 @@ export function createConsoleCaptureController({
     function readCaptured(limit = 50) {
         const entries = state.captured
             .slice(-limit)
-            .reverse()
             .map((entry) => ({
                 method: entry.method,
                 timestamp: entry.timestamp,
@@ -119,14 +183,19 @@ export function createConsoleCaptureController({
     }
 
     function flushToEruda() {
-        if (!getErudaReady() && !getConsoleTool()) {
+        if ((!getErudaReady() && !getConsoleTool()) || !state.captured.length) {
             return;
         }
         const start = Math.max(0, state.captured.length - maxErudaLogs, state.erudaFlushCursor);
-        for (let index = start; index < state.captured.length; index += 1) {
-            mirrorEntryToEruda(state.captured[index]);
+        state.erudaSyncingCapturedEntries = true;
+        try {
+            for (let index = start; index < state.captured.length; index += 1) {
+                mirrorEntryToEruda(state.captured[index]);
+            }
+            state.erudaFlushCursor = state.captured.length;
+        } finally {
+            state.erudaSyncingCapturedEntries = false;
         }
-        state.erudaFlushCursor = state.captured.length;
     }
 
     function handleMirroredEntry() {
@@ -138,7 +207,9 @@ export function createConsoleCaptureController({
 
     return {
         appendCapturedEntry,
+        attachErudaLogger,
         clearConsole,
+        detachErudaLogger,
         flushToEruda,
         getVisibleEntries,
         handleMirroredEntry,

--- a/src/app/ui/console/copy-visible-rows.js
+++ b/src/app/ui/console/copy-visible-rows.js
@@ -2,10 +2,10 @@ export function buildVisibleConsoleCopyText({
     classifyRow,
     getRows,
     getText,
+    orderRows = (rows) => rows,
     root,
 } = {}) {
-    return getRows(root)
-        .filter((row) => !row.hidden)
+    return orderRows(getRows(root).filter((row) => !row.hidden))
         .map((row) => {
             const timestamp = row.querySelector('.rav-console-time')?.textContent || '';
             const rowLevel = classifyRow(row);

--- a/src/app/ui/console/eruda/configure-tool.js
+++ b/src/app/ui/console/eruda/configure-tool.js
@@ -1,0 +1,43 @@
+export function configureErudaConsoleTool({
+    captureController,
+    consoleTool,
+    elements,
+    isSuppressed,
+    maxErudaLogs,
+}) {
+    captureController.restoreConsoleMethods();
+
+    const config = consoleTool.config;
+    if (config?.set) {
+        config.set('overrideConsole', true);
+        config.set('jsExecution', true);
+        config.set('catchGlobalErr', true);
+        config.set('asyncRender', false);
+        config.set('lazyEvaluation', true);
+    }
+
+    if (consoleTool._logger?.setOption) {
+        consoleTool._logger.setOption('asyncRender', false);
+        consoleTool._logger.setOption('maxNum', maxErudaLogs);
+        consoleTool._logger.setOption('lazyEvaluation', true);
+    } else if (consoleTool._logger?.options) {
+        consoleTool._logger.options.asyncRender = false;
+        consoleTool._logger.options.maxNum = maxErudaLogs;
+        consoleTool._logger.options.lazyEvaluation = true;
+    }
+
+    const lunaElement = elements.scriptConsoleOutput?.querySelector('.luna-console');
+    if (lunaElement) {
+        lunaElement.classList.remove('luna-console-theme-light');
+        lunaElement.classList.add('luna-console-theme-dark');
+    }
+
+    if (consoleTool._logger?.warn) {
+        const originalWarn = consoleTool._logger.warn.bind(consoleTool._logger);
+        consoleTool._logger.warn = (...args) => {
+            if (!isSuppressed(args)) {
+                originalWarn(...args);
+            }
+        };
+    }
+}

--- a/src/app/ui/console/eruda/presentation.js
+++ b/src/app/ui/console/eruda/presentation.js
@@ -42,20 +42,8 @@ export function createErudaPresentationController({
         return Array.from(container.querySelectorAll('.luna-console-log-container'));
     }
 
-    function getErudaRowGroups(container) {
-        const rows = getErudaRows(container);
-        const groups = new Map();
-        rows.forEach((row) => {
-            const parent = row.parentElement;
-            if (!parent) {
-                return;
-            }
-            if (!groups.has(parent)) {
-                groups.set(parent, []);
-            }
-            groups.get(parent).push(row);
-        });
-        return Array.from(groups.values());
+    function getDisplayedErudaRows(container) {
+        return getErudaRows(container);
     }
 
     function classifyErudaRow(row) {
@@ -195,21 +183,6 @@ export function createErudaPresentationController({
         }
     }
 
-    function reorderRowsNewestFirst(container) {
-        getErudaRowGroups(container).forEach((rows) => {
-            if (rows.length < 2) {
-                return;
-            }
-            const orderedRows = rows
-                .slice()
-                .sort((left, right) => Number(right.dataset.ravSeq || 0) - Number(left.dataset.ravSeq || 0));
-            if (!orderedRows.some((row, index) => row !== rows[index])) {
-                return;
-            }
-            orderedRows.forEach((row) => row.parentElement?.appendChild(row));
-        });
-    }
-
     function disconnectErudaObserver() {
         state.erudaObserver?.disconnect?.();
     }
@@ -235,7 +208,6 @@ export function createErudaPresentationController({
                 const rows = getErudaRows(container);
                 rows.forEach(ensureRowTimestamp);
                 rows.forEach(ensureRowBadge);
-                reorderRowsNewestFirst(container);
             });
             bindScrollContainer();
             applyErudaDomFilter();
@@ -259,14 +231,13 @@ export function createErudaPresentationController({
         state.erudaObserver = new MutationObserverCtor(() => {
             refreshErudaPresentation();
         });
-
         reconnectErudaObserver();
     }
 
     return {
         applyErudaDomFilter,
         classifyErudaRow,
-        getErudaLogContainers,
+        getDisplayedErudaRows,
         getErudaRows,
         observeErudaLogs,
         readErudaRowText,

--- a/src/app/ui/console/exec-outcome.js
+++ b/src/app/ui/console/exec-outcome.js
@@ -1,0 +1,40 @@
+export function normalizeConsoleEntries(entries, normalizeSerializable) {
+    return entries.map((entry) => ({
+        method: entry.method,
+        timestamp: entry.timestamp,
+        args: entry.args.map(normalizeSerializable),
+    }));
+}
+
+function resolveEntryPayload(entry) {
+    if (!entry || !Array.isArray(entry.args) || !entry.args.length) {
+        return undefined;
+    }
+    if (entry.args.length === 1) {
+        return entry.args[0];
+    }
+    return entry.args;
+}
+
+export function summarizeConsoleExecution({ code, entries, normalizeSerializable }) {
+    const normalizedEntries = normalizeConsoleEntries(entries, normalizeSerializable);
+    const resultEntry = normalizedEntries.findLast((entry) => entry.method === 'result');
+    const errorEntry = normalizedEntries.find((entry) => entry.method === 'error');
+    const ok = !errorEntry || !!resultEntry;
+
+    return {
+        ok,
+        code,
+        entries: normalizedEntries,
+        ...(resultEntry ? { result: resolveEntryPayload(resultEntry) } : {}),
+        ...(!ok && errorEntry ? { error: String(resolveEntryPayload(errorEntry) ?? 'Console execution failed') } : {}),
+    };
+}
+
+export async function waitForConsoleTranscript(setTimeoutFn) {
+    await Promise.resolve();
+    if (typeof setTimeoutFn !== 'function') {
+        return;
+    }
+    await new Promise((resolve) => setTimeoutFn(resolve, 0));
+}

--- a/src/app/ui/console/ui-state-controller.js
+++ b/src/app/ui/console/ui-state-controller.js
@@ -16,10 +16,9 @@ export function createConsoleUiStateController({
         if (!getErudaReady()) {
             return null;
         }
-        return elements.scriptConsoleOutput?.querySelector('.eruda-logs-container.luna-console')
-            || elements.scriptConsoleOutput?.querySelector('.rav-eruda .eruda-logs-container.luna-console')
+        return elements.scriptConsoleOutput?.querySelector('.rav-eruda .eruda-logs-container.luna-console')
+            || elements.scriptConsoleOutput?.querySelector('.eruda-logs-container.luna-console')
             || elements.scriptConsoleOutput?.querySelector('.luna-console')
-            || elements.scriptConsoleOutput?.querySelector('.luna-console-logs-space')
             || null;
     }
 
@@ -33,31 +32,10 @@ export function createConsoleUiStateController({
 
     function getLatestScrollTop() {
         const container = getScrollContainer();
-        const logList = getErudaLogList();
-        if (!container || !logList || container === logList) {
+        if (!container) {
             return 0;
         }
-        if (!logList.children.length) {
-            return 0;
-        }
-
-        const offsetTop = Number(logList.offsetTop);
-        if (Number.isFinite(offsetTop) && offsetTop > 0) {
-            return offsetTop;
-        }
-
-        const containerRect = typeof container.getBoundingClientRect === 'function'
-            ? container.getBoundingClientRect()
-            : null;
-        const logListRect = typeof logList.getBoundingClientRect === 'function'
-            ? logList.getBoundingClientRect()
-            : null;
-
-        if (!containerRect || !logListRect) {
-            return 0;
-        }
-
-        return Math.max(0, container.scrollTop + (logListRect.top - containerRect.top));
+        return Math.max(0, container.scrollHeight - container.clientHeight);
     }
 
     function syncLevelButtons() {
@@ -112,7 +90,7 @@ export function createConsoleUiStateController({
         if (!container) {
             return;
         }
-        const nextFollowLatest = Math.abs(container.scrollTop - getLatestScrollTop()) <= 6;
+        const nextFollowLatest = Math.abs(getLatestScrollTop() - container.scrollTop) <= 6;
         if (nextFollowLatest === state.followLatest) {
             return;
         }
@@ -178,6 +156,7 @@ export function createConsoleUiStateController({
 
     return {
         bindScrollContainer,
+        getErudaLogList,
         getListContainer,
         getScrollContainer,
         scrollConsoleToLatest,

--- a/src/app/ui/editor/editor-code-utils.js
+++ b/src/app/ui/editor/editor-code-utils.js
@@ -16,6 +16,24 @@ export function createTextareaEditorAdapter(textarea) {
     };
 }
 
+export function normalizeEditorDisplayCode(code) {
+    const text = String(code || '');
+    const trimmed = text.trim();
+    if (!trimmed.startsWith('({') || !trimmed.endsWith('})')) {
+        return text;
+    }
+
+    let start = text.indexOf(trimmed);
+    if (start === -1) {
+        start = 0;
+    }
+    const end = start + trimmed.length;
+    const leading = text.slice(0, start);
+    const trailing = text.slice(end);
+
+    return `${leading}${trimmed.slice(1, -1)}${trailing}`;
+}
+
 export function replaceOnLoadBlock(code, replacement) {
     const onLoadIdx = code.indexOf('onLoad:');
     if (onLoadIdx === -1) {

--- a/src/app/ui/event-log.js
+++ b/src/app/ui/event-log.js
@@ -39,12 +39,19 @@ export function createEventLogController({
             : 'Pinned follow is off';
     }
 
+    function getLatestScrollTop(container) {
+        if (!container) {
+            return 0;
+        }
+        return Math.max(0, container.scrollHeight - container.clientHeight);
+    }
+
     function syncFollowStateFromScroll() {
         const container = getScrollContainer();
         if (!container) {
             return;
         }
-        const nextFollowLatest = container.scrollTop <= 6;
+        const nextFollowLatest = Math.abs(getLatestScrollTop(container) - container.scrollTop) <= 6;
         if (nextFollowLatest === followLatest) {
             return;
         }
@@ -57,7 +64,7 @@ export function createEventLogController({
         if (!container) {
             return;
         }
-        container.scrollTop = 0;
+        container.scrollTop = getLatestScrollTop(container);
     }
 
     function syncFilterToggle(element, active) {
@@ -115,7 +122,7 @@ export function createEventLogController({
         if (elements.eventLogCopyButton) {
             elements.eventLogCopyButton.addEventListener('click', async () => {
                 const text = getVisibleEntries()
-                    .slice(0, 120)
+                    .slice(-120)
                     .map((entry) => `[${formatEventTime(entry.timestamp)}] ${entry.source.toUpperCase()} ${formatEventRowMessage(entry)}`)
                     .join('\n');
                 if (text) {
@@ -170,7 +177,7 @@ export function createEventLogController({
     }
 
     function logEvent(source, type, message, payload) {
-        eventLogEntries.unshift({
+        eventLogEntries.push({
             id: ++eventLogSequence,
             source,
             type,
@@ -179,7 +186,7 @@ export function createEventLogController({
             timestamp: Date.now(),
         });
         if (eventLogEntries.length > EVENT_LOG_LIMIT) {
-            eventLogEntries.length = EVENT_LOG_LIMIT;
+            eventLogEntries.splice(0, eventLogEntries.length - EVENT_LOG_LIMIT);
         }
         renderEventLog();
     }
@@ -211,7 +218,6 @@ export function createEventLogController({
 
         count.textContent = String(filtered.length);
         const scrollContainer = getScrollContainer();
-        const previousHeight = scrollContainer?.scrollHeight || 0;
         const previousTop = scrollContainer?.scrollTop || 0;
         list.innerHTML = '';
         if (!filtered.length) {
@@ -255,8 +261,7 @@ export function createEventLogController({
             scrollLatestIntoView();
             return;
         }
-        const heightDelta = scrollContainer.scrollHeight - previousHeight;
-        scrollContainer.scrollTop = previousTop + Math.max(0, heightDelta);
+        scrollContainer.scrollTop = Math.min(previousTop, getLatestScrollTop(scrollContainer));
     }
 
     function formatEventRowMessage(entry) {
@@ -331,7 +336,29 @@ export function createEventLogController({
         return { ...eventFilterState };
     }
 
+    function setFilter({ sources, search } = {}) {
+        if (Array.isArray(sources)) {
+            const allowed = new Set(['native', 'riveUser', 'ui', 'mcp']);
+            const wanted = new Set(sources.filter((source) => allowed.has(source)));
+            eventFilterState.native = wanted.has('native');
+            eventFilterState.riveUser = wanted.has('riveUser');
+            eventFilterState.ui = wanted.has('ui');
+            eventFilterState.mcp = wanted.has('mcp');
+            if (elements.eventFilterNative) syncFilterToggle(elements.eventFilterNative, eventFilterState.native);
+            if (elements.eventFilterRiveUser) syncFilterToggle(elements.eventFilterRiveUser, eventFilterState.riveUser);
+            if (elements.eventFilterUi) syncFilterToggle(elements.eventFilterUi, eventFilterState.ui);
+            if (elements.eventFilterMcp) syncFilterToggle(elements.eventFilterMcp, eventFilterState.mcp);
+        }
+        if (typeof search === 'string') {
+            eventFilterState.search = search.trim().toLowerCase();
+            if (elements.eventFilterSearch) elements.eventFilterSearch.value = search;
+        }
+        renderEventLog();
+        return getFilterStateSnapshot();
+    }
+
     return {
+        clearLog: resetEventLog,
         getEntriesSnapshot,
         getFilterStateSnapshot,
         isFollowingLatest: () => followLatest,
@@ -341,6 +368,7 @@ export function createEventLogController({
         resetEventLog,
         renderEventLog,
         setCollapsed,
+        setFilter,
         setupEventLog,
     };
 }

--- a/src/app/ui/export/control-tree.js
+++ b/src/app/ui/export/control-tree.js
@@ -44,6 +44,7 @@ function createInputRow({ depth, documentRef, input, onSelectionChange, selected
     const checkbox = documentRef.createElement('input');
     checkbox.type = 'checkbox';
     const key = controlSnapshotKeyForDescriptor(input?.descriptor);
+    if (key) checkbox.setAttribute('data-control-key', key);
     checkbox.checked = Boolean(key && selectedKeys?.has(key));
     checkbox.disabled = !key;
     checkbox.addEventListener('change', () => {

--- a/src/app/ui/script-console.js
+++ b/src/app/ui/script-console.js
@@ -1,19 +1,19 @@
 import { writeTextToClipboard } from './console/io/clipboard.js';
 import { createConsoleCaptureController } from './console/capture-controller.js';
 import { buildVisibleConsoleCopyText } from './console/copy-visible-rows.js';
+import { summarizeConsoleExecution, waitForConsoleTranscript } from './console/exec-outcome.js';
 import { loadErudaConsole } from './console/eruda/loader.js';
+import { configureErudaConsoleTool } from './console/eruda/configure-tool.js';
 import { createErudaPresentationController } from './console/eruda/presentation.js';
 import { formatEntryMessage, formatTimestamp, normalizeSerializable, resolveEntryBadge, resolveEntryLevel } from './console/formatting.js';
 import { createReplHistoryController } from './console/repl-history-controller.js';
 import { registerConsoleBindings } from './console/setup-bindings.js';
 import { createConsoleUiStateController } from './console/ui-state-controller.js';
-
 const ERUDA_VENDOR_PATH = '/vendor/eruda.js';
 const MAX_CAPTURED = 1200;
 const MAX_ERUDA_LOGS = 500;
 const COMMAND_HISTORY_LIMIT = 100;
 const SUPPRESSED_WARNINGS = ['Measure loop'];
-
 export function createScriptConsoleController({
     elements,
     callbacks = {},
@@ -23,7 +23,6 @@ export function createScriptConsoleController({
     windowRef = globalThis.window,
 } = {}) {
     const { logEvent = () => {}, onOpenChange = () => {}, onToggleRequested = null, renderEventLog = () => {} } = callbacks;
-
     const state = {
         captureInstalled: false,
         captured: [],
@@ -33,10 +32,13 @@ export function createScriptConsoleController({
         currentLevel: 'all',
         erudaFlushCursor: 0,
         erudaLoadPromise: null,
+        erudaInsertHandler: null,
+        erudaLogger: null,
         erudaObserver: null,
         erudaPresentationSyncing: false,
         erudaReady: false,
         erudaRowSequence: 0,
+        erudaSyncingCapturedEntries: false,
         followLatest: true,
         historyIndex: -1,
         historyPending: '',
@@ -50,7 +52,6 @@ export function createScriptConsoleController({
 
     const isSuppressed = (args) =>
         typeof args?.[0] === 'string' && SUPPRESSED_WARNINGS.some((needle) => args[0].includes(needle));
-
     function getConsoleTool() {
         if (state.consoleTool) return state.consoleTool;
         if (windowRef?.eruda && typeof windowRef.eruda.get === 'function') {
@@ -69,7 +70,6 @@ export function createScriptConsoleController({
         getErudaReady: () => state.erudaReady,
         state,
     });
-
     const erudaPresentation = createErudaPresentationController({
         bindScrollContainer: uiStateController.bindScrollContainer,
         documentRef,
@@ -91,7 +91,6 @@ export function createScriptConsoleController({
         const scrollContainer = uiStateController.getScrollContainer();
         if (!list) return;
 
-        const previousHeight = scrollContainer?.scrollHeight || 0;
         const previousTop = scrollContainer?.scrollTop || 0;
         const visibleEntries = captureController.getVisibleEntries({
             currentLevel: state.currentLevel,
@@ -132,7 +131,8 @@ export function createScriptConsoleController({
             uiStateController.scrollConsoleToLatest();
             return;
         }
-        scrollContainer.scrollTop = previousTop + Math.max(0, scrollContainer.scrollHeight - previousHeight);
+        const latestScrollTop = Math.max(0, scrollContainer.scrollHeight - scrollContainer.clientHeight);
+        scrollContainer.scrollTop = Math.min(previousTop, latestScrollTop);
     }
 
     function mirrorEntryToEruda(entry) {
@@ -163,6 +163,13 @@ export function createScriptConsoleController({
         maxErudaLogs: MAX_ERUDA_LOGS,
         mirrorEntryToEruda,
         normalizeSerializable: (value) => normalizeSerializable(value, windowRef),
+        onErudaInsert: () => {
+            erudaPresentation.refreshErudaPresentation();
+            uiStateController.bindScrollContainer();
+            if (state.followLatest) {
+                setTimeoutFn?.(() => uiStateController.scrollConsoleToLatest(), 0);
+            }
+        },
         renderConsoleEntries,
         scrollConsoleToLatest: uiStateController.scrollConsoleToLatest,
         setTimeoutFn,
@@ -184,30 +191,13 @@ export function createScriptConsoleController({
         state.erudaLoadPromise = loadErudaConsole({
             captureController,
             configureConsoleTool: (consoleTool) => {
-                const config = consoleTool.config;
-                if (config?.set) {
-                    config.set('overrideConsole', true);
-                    config.set('jsExecution', true);
-                    config.set('catchGlobalErr', true);
-                    config.set('asyncRender', true);
-                    config.set('lazyEvaluation', true);
-                }
-                if (consoleTool._logger?.options) {
-                    consoleTool._logger.options.maxNum = MAX_ERUDA_LOGS;
-                }
-                const lunaElement = elements.scriptConsoleOutput?.querySelector('.luna-console');
-                if (lunaElement) {
-                    lunaElement.classList.remove('luna-console-theme-light');
-                    lunaElement.classList.add('luna-console-theme-dark');
-                }
-                if (consoleTool._logger?.warn) {
-                    const originalWarn = consoleTool._logger.warn.bind(consoleTool._logger);
-                    consoleTool._logger.warn = (...args) => {
-                        if (!isSuppressed(args)) {
-                            originalWarn(...args);
-                        }
-                    };
-                }
+                configureErudaConsoleTool({
+                    captureController,
+                    consoleTool,
+                    elements,
+                    isSuppressed,
+                    maxErudaLogs: MAX_ERUDA_LOGS,
+                });
             },
             documentRef,
             elements,
@@ -216,7 +206,10 @@ export function createScriptConsoleController({
             erudaVendorPath: ERUDA_VENDOR_PATH,
             getFollowLatest: () => state.followLatest,
             getWindowEruda: () => windowRef?.eruda,
-            onConsoleReady: () => { state.erudaReady = true; },
+            onConsoleReady: () => {
+                state.erudaReady = true;
+                captureController.attachErudaLogger(state.consoleTool?._logger || null);
+            },
             onScrollContainerReady: uiStateController.bindScrollContainer,
             scrollConsoleToLatest: uiStateController.scrollConsoleToLatest,
             setTimeoutFn,
@@ -235,11 +228,8 @@ export function createScriptConsoleController({
 
     function applyErudaFilter() {
         erudaPresentation.applyErudaDomFilter();
-        if (state.followLatest) {
-            setTimeoutFn?.(() => uiStateController.scrollConsoleToLatest(), 30);
-        }
+        if (state.followLatest) setTimeoutFn?.(() => uiStateController.scrollConsoleToLatest(), 30);
     }
-
     function syncUi() { uiStateController.syncUi(); uiStateController.syncLevelButtons(); uiStateController.syncFollowButton(); }
 
     async function openConsole() {
@@ -255,7 +245,6 @@ export function createScriptConsoleController({
         if (!state.erudaReady) renderConsoleEntries();
         return { open: true };
     }
-
     function closeConsole() {
         state.isOpen = false;
         syncUi();
@@ -263,7 +252,6 @@ export function createScriptConsoleController({
         onOpenChange(false);
         return { open: false };
     }
-
     async function evaluateConsoleSource(source) {
         try {
             return await windowRef.eval(`(async () => (${source}))()`);
@@ -278,6 +266,8 @@ export function createScriptConsoleController({
             return { ok: false, error: 'code is required' };
         }
 
+        const capturedCountBeforeExec = state.captured.length;
+
         try {
             if (!state.isOpen) {
                 await openConsole();
@@ -285,15 +275,19 @@ export function createScriptConsoleController({
 
             const consoleTool = getConsoleTool();
             if (consoleTool?._logger?.evaluate) {
-                captureController.appendCapturedEntry({ method: 'command', args: [source], timestamp: Date.now() }, { mirrorToEruda: false });
                 const evaluation = consoleTool._logger.evaluate(source);
                 if (typeof evaluation?.then === 'function') await evaluation;
+                await waitForConsoleTranscript(setTimeoutFn);
                 erudaPresentation.refreshErudaPresentation();
                 uiStateController.bindScrollContainer();
                 if (state.followLatest) {
                     setTimeoutFn?.(() => uiStateController.scrollConsoleToLatest(), 50);
                 }
-                return { ok: true, code: source };
+                return summarizeConsoleExecution({
+                    code: source,
+                    entries: state.captured.slice(capturedCountBeforeExec),
+                    normalizeSerializable: (value) => normalizeSerializable(value, windowRef),
+                });
             }
 
             captureController.appendCapturedEntry({ method: 'command', args: [source], timestamp: Date.now() });
@@ -301,11 +295,19 @@ export function createScriptConsoleController({
             if (result !== undefined) {
                 captureController.appendCapturedEntry({ method: 'result', args: [normalizeSerializable(result, windowRef)], timestamp: Date.now() });
             }
-            return { ok: true, code: source, result: normalizeSerializable(result, windowRef) };
+            return summarizeConsoleExecution({
+                code: source,
+                entries: state.captured.slice(capturedCountBeforeExec),
+                normalizeSerializable: (value) => normalizeSerializable(value, windowRef),
+            });
         } catch (error) {
             captureController.appendCapturedEntry({ method: 'error', args: [error.message], timestamp: Date.now() });
             logEvent('ui', 'console-exec-failed', error.message);
-            return { ok: false, code: source, error: error.message };
+            return summarizeConsoleExecution({
+                code: source,
+                entries: state.captured.slice(capturedCountBeforeExec),
+                normalizeSerializable: (value) => normalizeSerializable(value, windowRef),
+            });
         }
     }
 
@@ -322,6 +324,7 @@ export function createScriptConsoleController({
                     classifyRow: erudaPresentation.classifyErudaRow,
                     getRows: erudaPresentation.getErudaRows,
                     getText: erudaPresentation.readErudaRowText,
+                    orderRows: (rows) => rows,
                     root: elements.scriptConsoleOutput?.querySelector('.luna-console-logs'),
                 });
                 if (text) {
@@ -366,6 +369,7 @@ export function createScriptConsoleController({
         syncUi();
         onOpenChange(false);
         replHistoryController.destroy();
+        captureController.detachErudaLogger();
         try {
             windowRef?.eruda?.destroy?.();
         } catch {
@@ -379,7 +383,18 @@ export function createScriptConsoleController({
         captureController.restoreConsoleMethods();
     }
 
+    function setFilter({ level, search } = {}) {
+        if (level === 'all' || level === 'info' || level === 'warning' || level === 'error') {
+            state.currentLevel = level;
+            uiStateController.syncLevelButtons();
+        }
+        if (typeof search === 'string' && elements.scriptConsoleFilterSearch) elements.scriptConsoleFilterSearch.value = search;
+        if (state.erudaReady) applyErudaFilter(); else renderConsoleEntries();
+        return { level: state.currentLevel, search: String(elements.scriptConsoleFilterSearch?.value || '') };
+    }
+
     return {
+        clear: () => captureController.clearConsole(),
         close: closeConsole,
         destroy,
         exec,
@@ -388,6 +403,7 @@ export function createScriptConsoleController({
         isOpen: () => state.isOpen,
         open: openConsole,
         readCaptured: captureController.readCaptured,
+        setFilter,
         setup,
     };
 }

--- a/styles/09-script-console.css
+++ b/styles/09-script-console.css
@@ -105,6 +105,7 @@ body.js-console-mode > .eruda-container:not(.rav-eruda) {
 .script-console-output .luna-console {
     background: #0a0d13 !important;
     font-family: "Space Mono", monospace !important;
+    overflow-y: auto !important;
 }
 
 .script-console-output .luna-console-fake-logs {
@@ -112,8 +113,11 @@ body.js-console-mode > .eruda-container:not(.rav-eruda) {
 }
 
 .script-console-output .luna-console-logs {
+    display: flex !important;
+    flex-direction: column !important;
+    min-height: 100%;
     background: #0a0d13 !important;
-    overflow-y: auto !important;
+    overflow: visible !important;
 }
 
 .script-console-output .luna-console-log-container {

--- a/tests/unit/ui/code-editor.test.js
+++ b/tests/unit/ui/code-editor.test.js
@@ -8,15 +8,15 @@ import {
 
 describe('ui/code-editor', () => {
     it('replaces and extracts onLoad blocks', () => {
-        const baseCode = `({
+        const baseCode = `{
   autoplay: true,
   onLoad: () => {
     console.log("ready");
   }
-})`;
+}`;
 
         expect(replaceOnLoadBlock(baseCode, 'onLoad: () => { riveInst.play(); }')).toContain('riveInst.play();');
-        expect(replaceOnLoadBlock('({ autoplay: true })', 'onLoad: () => { riveInst.play(); }')).toContain('onLoad: () => { riveInst.play(); }');
+        expect(replaceOnLoadBlock('{ autoplay: true }', 'onLoad: () => { riveInst.play(); }')).toContain('onLoad: () => { riveInst.play(); }');
 
         const source = 'const snippet = `onLoad: () => { if (true) { riveInst.play(); } }`;';
         const start = source.indexOf('onLoad:');
@@ -24,14 +24,14 @@ describe('ui/code-editor', () => {
     });
 
     it('evaluates object configs and rejects invalid values', () => {
-        expect(evaluateEditorConfig('({ autoplay: true, stateMachines: "main" })')).toEqual({
+        expect(evaluateEditorConfig('{ autoplay: true, stateMachines: "main" }')).toEqual({
             autoplay: true,
             stateMachines: 'main',
         });
         expect(() => evaluateEditorConfig('[]')).toThrow('Initialization config must return an object');
         expect(() => evaluateEditorConfig('({')).toThrow('Invalid JavaScript config');
         expect(hasVmExplorerSnippet('onLoad: () => { vmExplore(); }')).toBe(true);
-        expect(hasVmExplorerSnippet('({ autoplay: true })')).toBe(false);
+        expect(hasVmExplorerSnippet('{ autoplay: true }')).toBe(false);
     });
 
     it('boots the fallback editor, reloads the animation, and toggles the VM explorer snippet', async () => {
@@ -91,7 +91,7 @@ describe('ui/code-editor', () => {
         expect(controller.getEditorCode()).not.toContain('window.vmExplore = exploreVmLevel;');
         expect(controller.getVmExplorerSnippetState()).toEqual({ injected: false });
 
-        controller.setEditorCode('({ autoplay: false, canvasSize: { mode: "fixed", width: 1920, height: 1080, lockAspectRatio: true } })');
+        controller.setEditorCode('{ autoplay: false, canvasSize: { mode: "fixed", width: 1920, height: 1080, lockAspectRatio: true } }');
         expect(controller.getEditorConfig()).toEqual({
             autoplay: false,
             canvasSize: {
@@ -129,7 +129,7 @@ describe('ui/code-editor', () => {
             loadCodeMirror: async () => false,
         });
 
-        expect(controller.setEditorCode('({ autoplay: false })')).toBe(false);
+        expect(controller.setEditorCode('{ autoplay: false }')).toBe(false);
         expect(controller.getEditorConfig()).toEqual({});
 
         await controller.applyCodeAndReload();
@@ -229,7 +229,7 @@ describe('ui/code-editor', () => {
         expect(editorInstance.dispatch).toHaveBeenCalled();
 
         controller.setEditorCode('({ autoplay: false, autoBind: true })');
-        expect(controller.getEditorCode()).toBe('({ autoplay: false, autoBind: true })');
+        expect(controller.getEditorCode()).toBe('{ autoplay: false, autoBind: true }');
     });
 
     it('supports explicit live-source and VM explorer state changes', async () => {

--- a/tests/unit/ui/event-log.test.js
+++ b/tests/unit/ui/event-log.test.js
@@ -61,7 +61,7 @@ describe('ui/event-log', () => {
         });
     });
 
-    it('renders events and exposes snapshots', () => {
+    it('renders events in natural order and exposes snapshots', () => {
         const handleResize = vi.fn();
         const controller = createEventLogController({
             elements: buildElements(),
@@ -75,6 +75,10 @@ describe('ui/event-log', () => {
         expect(controller.getEntriesSnapshot()).toHaveLength(2);
         expect(document.getElementById('event-log-count').textContent).toBe('2');
         expect(document.getElementById('event-log-list').textContent).toContain('Bridge connected');
+        const rows = Array.from(document.querySelectorAll('#event-log-list .event-log-row'));
+        expect(rows).toHaveLength(2);
+        expect(rows[0].textContent).toContain('Viewer ready');
+        expect(rows[1].textContent).toContain('Bridge connected');
     });
 
     it('renders cyclic payloads without crashing the event log', () => {
@@ -128,20 +132,25 @@ describe('ui/event-log', () => {
         expect(navigator.clipboard.writeText).toHaveBeenCalled();
     });
 
-    it('turns follow off when scrolled away and back on when toggled', () => {
+    it('turns follow off when scrolled away from the bottom and back on when toggled', () => {
         const controller = createEventLogController({
             elements: buildElements(),
             handleResize: vi.fn(),
         });
 
         controller.setupEventLog();
-        controller.logEvent('ui', 'ready', 'Viewer ready');
         const body = document.getElementById('event-log-body');
+        Object.defineProperty(body, 'clientHeight', { configurable: true, value: 140 });
+        let scrollHeight = 440;
+        Object.defineProperty(body, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+        controller.logEvent('ui', 'ready', 'Viewer ready');
+        controller.logEvent('ui', 'next', 'Another entry');
         body.scrollTop = 32;
         body.dispatchEvent(new Event('scroll'));
         expect(controller.isFollowingLatest()).toBe(false);
 
         document.getElementById('event-log-follow-btn').click();
         expect(controller.isFollowingLatest()).toBe(true);
+        expect(body.scrollTop).toBe(scrollHeight - body.clientHeight);
     });
 });

--- a/tests/unit/ui/script-console.test.js
+++ b/tests/unit/ui/script-console.test.js
@@ -31,7 +31,26 @@ function renderShell() {
     return getElements(document);
 }
 
-function createFakeEruda() {
+function createInsertEmitter() {
+    const listeners = new Map();
+
+    return {
+        emit(event, payload) {
+            listeners.get(event)?.forEach((handler) => handler(payload));
+        },
+        off: vi.fn((event, handler) => {
+            listeners.get(event)?.delete(handler);
+        }),
+        on: vi.fn((event, handler) => {
+            if (!listeners.has(event)) {
+                listeners.set(event, new Set());
+            }
+            listeners.get(event).add(handler);
+        }),
+    };
+}
+
+function createFakeErudaHarness({ nested = false } = {}) {
     const consoleScroller = document.createElement('div');
     consoleScroller.className = 'eruda-logs-container luna-console luna-console-platform-mac luna-console-theme-dark';
     consoleScroller.scrollTop = 0;
@@ -58,56 +77,123 @@ function createFakeEruda() {
         value: 280,
     });
 
-    function appendLogRow(type, text) {
-        function buildRow() {
-            const row = document.createElement('div');
-            row.className = 'luna-console-log-container';
+    let visibleParent = logs;
+    let fakeParent = fakeLogs;
+    let logsSpace = null;
+    let logRows = logs;
 
-            const item = document.createElement('div');
-            item.className = `luna-console-${type} luna-console-log-item`;
+    if (nested) {
+        const fakeRows = document.createElement('div');
+        fakeRows.className = 'fake-rows';
+        fakeLogs.appendChild(fakeRows);
+        fakeParent = fakeRows;
 
-            const content = document.createElement('div');
-            content.className = 'luna-console-log-content';
-            content.textContent = text;
+        logsSpace = document.createElement('div');
+        logsSpace.className = 'luna-console-logs-space';
+        logRows = document.createElement('div');
+        logRows.className = 'log-rows';
+        logs.appendChild(logRows);
+        logsSpace.appendChild(logs);
+        visibleParent = logRows;
+    }
 
-            item.appendChild(content);
-            row.appendChild(item);
-            return row;
-        }
+    function buildRow(type, text) {
+        const row = document.createElement('div');
+        row.className = 'luna-console-log-container';
 
-        const visibleRow = buildRow();
-        logs.appendChild(visibleRow);
+        const item = document.createElement('div');
+        item.className = `luna-console-${type} luna-console-log-item`;
 
-        const fakeRow = buildRow();
-        fakeLogs.appendChild(fakeRow);
+        const content = document.createElement('div');
+        content.className = 'luna-console-log-content';
+        content.textContent = text;
+
+        item.appendChild(content);
+        row.appendChild(item);
+        return row;
+    }
+
+    const loggerEvents = createInsertEmitter();
+    let overrideApplied = false;
+    const originalConsole = {};
+
+    function emitInsert(type, args, text) {
+        loggerEvents.emit('insert', {
+            args,
+            header: text,
+            type,
+        });
+    }
+
+    function appendLogRow(type, text, args = [text]) {
+        visibleParent.appendChild(buildRow(type, text));
+        fakeParent.appendChild(buildRow(type, text));
+        emitInsert(type, args, text);
     }
 
     function appendConsoleRow(type, args) {
-        appendLogRow(type, args.join(' '));
+        appendLogRow(type, args.join(' '), args);
     }
 
-    function appendEvalRows(source) {
-        appendLogRow('input', source);
-        appendLogRow('output', `result:${source}`);
+    function applyOverrideConsole(tool) {
+        if (overrideApplied) {
+            return;
+        }
+        overrideApplied = true;
+        ['log', 'info', 'warn', 'error', 'debug', 'dir'].forEach((method) => {
+            originalConsole[method] = window.console[method].bind(window.console);
+            window.console[method] = (...args) => {
+                tool[method](...args);
+                return originalConsole[method](...args);
+            };
+        });
+    }
+
+    function restoreOverrideConsole() {
+        if (!overrideApplied) {
+            return;
+        }
+        overrideApplied = false;
+        Object.entries(originalConsole).forEach(([method, original]) => {
+            window.console[method] = original;
+        });
     }
 
     const tool = {
         _logger: {
             evaluate: vi.fn((source) => {
-                appendEvalRows(source);
+                appendLogRow('input', source, [source]);
+                appendLogRow('output', `result:${source}`, [`result:${source}`]);
                 return undefined;
             }),
+            off: loggerEvents.off,
+            on: loggerEvents.on,
             options: {},
+            setOption: vi.fn((name, value) => {
+                tool._logger.options[name] = value;
+            }),
             warn: vi.fn(),
         },
         clear: vi.fn(() => {
-            logs.innerHTML = '';
-            fakeLogs.innerHTML = '';
+            visibleParent.innerHTML = '';
+            fakeParent.innerHTML = '';
         }),
         config: {
-            set: vi.fn(),
+            set: vi.fn((name, value) => {
+                if (name === 'overrideConsole') {
+                    if (value) {
+                        applyOverrideConsole(tool);
+                    } else {
+                        restoreOverrideConsole();
+                    }
+                }
+                if (tool._logger.setOption) {
+                    tool._logger.setOption(name, value);
+                }
+            }),
         },
         debug: vi.fn((...args) => appendConsoleRow('debug', args)),
+        dir: vi.fn((...args) => appendConsoleRow('dir', args)),
         error: vi.fn((...args) => appendConsoleRow('error', args)),
         filter: vi.fn(),
         info: vi.fn((...args) => appendConsoleRow('info', args)),
@@ -116,7 +202,9 @@ function createFakeEruda() {
     };
 
     const eruda = {
-        destroy: vi.fn(),
+        destroy: vi.fn(() => {
+            restoreOverrideConsole();
+        }),
         get: vi.fn(() => tool),
         init: vi.fn(({ container }) => {
             const erudaContainer = document.createElement('div');
@@ -127,7 +215,7 @@ function createFakeEruda() {
             const consoleEl = document.createElement('div');
             consoleEl.className = 'eruda-console';
             consoleScroller.appendChild(fakeLogs);
-            consoleScroller.appendChild(logs);
+            consoleScroller.appendChild(logsSpace || logs);
             consoleEl.appendChild(consoleScroller);
             devTools.appendChild(consoleEl);
             erudaContainer.appendChild(devTools);
@@ -137,110 +225,15 @@ function createFakeEruda() {
         show: vi.fn(),
     };
 
-    return { consoleScroller, eruda, fakeLogs, logs, tool };
+    return { consoleScroller, eruda, fakeLogs, logs, logRows, tool };
+}
+
+function createFakeEruda() {
+    return createFakeErudaHarness();
 }
 
 function createNestedFakeEruda() {
-    const consoleScroller = document.createElement('div');
-    consoleScroller.className = 'eruda-logs-container luna-console luna-console-platform-mac luna-console-theme-dark';
-    consoleScroller.scrollTop = 0;
-    Object.defineProperty(consoleScroller, 'clientHeight', {
-        configurable: true,
-        value: 100,
-    });
-    Object.defineProperty(consoleScroller, 'scrollHeight', {
-        configurable: true,
-        get: () => 400,
-    });
-
-    const fakeLogs = document.createElement('div');
-    fakeLogs.className = 'luna-console-fake-logs';
-    const fakeRows = document.createElement('div');
-    fakeRows.className = 'fake-rows';
-    fakeLogs.appendChild(fakeRows);
-    Object.defineProperty(fakeLogs, 'offsetTop', {
-        configurable: true,
-        value: 0,
-    });
-
-    const logsSpace = document.createElement('div');
-    logsSpace.className = 'luna-console-logs-space';
-
-    const logs = document.createElement('div');
-    logs.className = 'luna-console-logs';
-    const logRows = document.createElement('div');
-    logRows.className = 'log-rows';
-    logs.appendChild(logRows);
-    logsSpace.appendChild(logs);
-    Object.defineProperty(logs, 'offsetTop', {
-        configurable: true,
-        value: 280,
-    });
-
-    function buildRow(type, text) {
-        const row = document.createElement('div');
-        row.className = 'luna-console-log-container';
-        const item = document.createElement('div');
-        item.className = `luna-console-${type} luna-console-log-item`;
-        const content = document.createElement('div');
-        content.className = 'luna-console-log-content';
-        content.textContent = text;
-        item.appendChild(content);
-        row.appendChild(item);
-        return row;
-    }
-
-    function appendLogRow(type, text) {
-        logRows.appendChild(buildRow(type, text));
-        fakeRows.appendChild(buildRow(type, text));
-    }
-
-    const tool = {
-        _logger: {
-            evaluate: vi.fn((source) => {
-                appendLogRow('input', source);
-                appendLogRow('output', `result:${source}`);
-                return undefined;
-            }),
-            options: {},
-            warn: vi.fn(),
-        },
-        clear: vi.fn(() => {
-            logRows.innerHTML = '';
-            fakeRows.innerHTML = '';
-        }),
-        config: {
-            set: vi.fn(),
-        },
-        info: vi.fn((...args) => appendLogRow('info', args.join(' '))),
-        log: vi.fn((...args) => appendLogRow('log', args.join(' '))),
-        warn: vi.fn((...args) => appendLogRow('warn', args.join(' '))),
-        error: vi.fn((...args) => appendLogRow('error', args.join(' '))),
-        debug: vi.fn((...args) => appendLogRow('debug', args.join(' '))),
-    };
-
-    const eruda = {
-        destroy: vi.fn(),
-        get: vi.fn(() => tool),
-        init: vi.fn(({ container }) => {
-            const erudaContainer = document.createElement('div');
-            erudaContainer.className = 'eruda-container';
-            const devTools = document.createElement('div');
-            devTools.className = 'eruda-dev-tools';
-            const consoleEl = document.createElement('div');
-            consoleEl.className = 'eruda-console';
-            consoleScroller.appendChild(fakeLogs);
-            consoleScroller.appendChild(logsSpace);
-            consoleEl.appendChild(consoleScroller);
-            devTools.appendChild(consoleEl);
-            erudaContainer.appendChild(devTools);
-            container.appendChild(erudaContainer);
-        }),
-        remove: vi.fn(),
-        show: vi.fn(),
-    };
-
-    return { consoleScroller, eruda, logRows, tool };
+    return createFakeErudaHarness({ nested: true });
 }
 
 function immediateSetTimeout(callback) {
@@ -305,7 +298,7 @@ describe('ui/script-console', () => {
         expect(window.console.log).not.toBe(wrappedLog);
     });
 
-    it('opens in javascript-console mode, executes code, and renders newest output at the top', async () => {
+    it('opens in javascript-console mode, executes code, and keeps native Eruda order', async () => {
         const elements = renderShell();
         const renderEventLog = vi.fn();
         const { eruda, tool } = createFakeEruda();
@@ -338,6 +331,27 @@ describe('ui/script-console', () => {
         expect(elements.eventConsoleTab.classList.contains('is-active')).toBe(true);
         expect(elements.scriptConsoleTab.classList.contains('is-active')).toBe(false);
         expect(renderEventLog).toHaveBeenCalled();
+    });
+
+    it('captures one transcript entry per overridden console call after Eruda loads', async () => {
+        const elements = renderShell();
+        const { eruda } = createFakeEruda();
+        window.eruda = eruda;
+        const controller = track(createScriptConsoleController({
+            elements,
+            setTimeoutFn: immediateSetTimeout,
+        }));
+
+        controller.installCapture();
+        controller.setup();
+        await controller.open();
+
+        console.info('single-entry');
+
+        const entries = controller.readCaptured(10).entries;
+        expect(entries).toHaveLength(1);
+        expect(entries[0].method).toBe('info');
+        expect(entries[0].args).toEqual(['single-entry']);
     });
 
     it('applies filters, supports copy, clears output, and updates follow state on the live eruda scroller', async () => {
@@ -387,7 +401,7 @@ describe('ui/script-console', () => {
 
         elements.scriptConsoleFollowButton.click();
         expect(controller.isFollowingLatest()).toBe(true);
-        expect(scrollContainer.scrollTop).toBe(280);
+        expect(scrollContainer.scrollTop).toBe(scrollContainer.scrollHeight - scrollContainer.clientHeight);
 
         elements.scriptConsoleClearButton.click();
         expect(tool.clear).toHaveBeenCalled();
@@ -423,11 +437,14 @@ describe('ui/script-console', () => {
         tool._logger.evaluate.mockImplementationOnce(() => {
             throw new Error('boom');
         });
-        await expect(controller.exec('throw new Error("boom")')).resolves.toEqual({
+        await expect(controller.exec('throw new Error("boom")')).resolves.toEqual(expect.objectContaining({
             code: 'throw new Error("boom")',
+            entries: expect.arrayContaining([
+                expect.objectContaining({ method: 'error', args: ['boom'] }),
+            ]),
             error: 'boom',
             ok: false,
-        });
+        }));
         expect(execLogEvent).toHaveBeenCalledWith('ui', 'console-exec-failed', 'boom');
     });
 
@@ -456,15 +473,20 @@ describe('ui/script-console', () => {
 
         controller.setup();
         await controller.open();
-        await expect(controller.exec('riveInst')).resolves.toEqual({
+        await expect(controller.exec('riveInst')).resolves.toEqual(expect.objectContaining({
             code: 'riveInst',
+            entries: expect.arrayContaining([
+                expect.objectContaining({ method: 'command', args: ['riveInst'] }),
+                expect.objectContaining({ method: 'result', args: ['result:riveInst'] }),
+            ]),
             ok: true,
-        });
+            result: 'result:riveInst',
+        }));
         expect(tool._logger.evaluate).toHaveBeenCalledWith('riveInst');
-        expect(controller.readCaptured(5).entries[0].method).toBe('command');
+        expect(controller.readCaptured(5).entries.at(-1).method).toBe('result');
     });
 
-    it('prepends timestamps and keeps the newest eruda rows at the top', async () => {
+    it('prepends timestamps and badges while leaving Eruda DOM order intact', async () => {
         const elements = renderShell();
         const { eruda, logs } = createFakeEruda();
         const controller = track(createScriptConsoleController({
@@ -488,10 +510,10 @@ describe('ui/script-console', () => {
 
         const rows = Array.from(logs.children);
         expect(rows).toHaveLength(2);
-        expect(rows[0].textContent).toContain('second');
+        expect(rows[0].textContent).toContain('first');
         expect(rows[0].querySelector('.rav-console-time')).toBeTruthy();
         expect(rows[0].querySelector('.rav-console-badge')?.textContent).toBe('LOG');
-        expect(rows[1].textContent).toContain('first');
+        expect(rows[1].textContent).toContain('second');
         expect(rows[1].querySelector('.rav-console-time')).toBeTruthy();
         expect(rows[1].querySelector('.rav-console-badge')?.textContent).toBe('LOG');
     });
@@ -515,11 +537,11 @@ describe('ui/script-console', () => {
 
         const rows = Array.from(logs.children);
         expect(rows).toHaveLength(2);
-        expect(rows[0].querySelector('.rav-console-badge')?.textContent).toBe('RESULT');
-        expect(rows[1].querySelector('.rav-console-badge')?.textContent).toBe('CMD');
+        expect(rows[0].querySelector('.rav-console-badge')?.textContent).toBe('CMD');
+        expect(rows[1].querySelector('.rav-console-badge')?.textContent).toBe('RESULT');
     });
 
-    it('keeps nested eruda command and result rows at the top', async () => {
+    it('keeps nested eruda command and result rows in Eruda order', async () => {
         const elements = renderShell();
         const { eruda, logRows } = createNestedFakeEruda();
         const controller = track(createScriptConsoleController({
@@ -540,9 +562,9 @@ describe('ui/script-console', () => {
 
         const rows = Array.from(logRows.querySelectorAll('.luna-console-log-container'));
         expect(rows).toHaveLength(3);
-        expect(rows[0].textContent).toContain('result:1 + 1');
+        expect(rows[0].textContent).toContain('older');
         expect(rows[1].textContent).toContain('1 + 1');
-        expect(rows[2].textContent).toContain('older');
+        expect(rows[2].textContent).toContain('result:1 + 1');
     });
 
     it('disconnects the eruda observer while normalizing DOM rows', async () => {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,8 +4,21 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-10
+
+### Added
+
+- **MCP `rav_console_set_mode`** — Flip the bottom console between Event Console, JS REPL, or closed without re-opening the panel.
+- **MCP `rav_console_set_filter`** — Drive the existing on-screen filter toggles from any MCP client. JS mode supports `level` (`all`/`info`/`warning`/`error`); Event mode supports `sources` (subset of `native`/`riveUser`/`ui`/`mcp`); both modes support `search`. Auto-targets the active mode when `mode` is omitted.
+- **MCP `rav_console_clear`** — Clear the visible transcript of the active mode (or a specified mode) without closing the panel.
+- **Extended MCP `rav_console_open`** — Optional `mode`, `level`, `sources`, and `search` apply pre-configured filter state in the same call. Backwards compatible with no-argument invocations.
+- **MCP `rav_export_demo_visual`** — Orchestrates the Snippet & Export Controls dialog visually (open → selection → package/mode → click Export → save) for screen recordings or non-default control selections.
+- **Docs** — MCP Integration page now lists 36 tools with the four new console-control rows and the visual export row.
+- **Landing** — Features section updated to advertise 36 MCP tools and console panel control.
+
 ### Changed
 
+- **Script console refactor** — Internal Eruda configuration extracted into dedicated modules; capture controller now owns logger attachment and type mapping. No user-visible behavior change.
 - **Regression guardrails** — Documented the current prebuild protection stack around architecture drift, dependency boundaries, custom window chrome, and exported demo chrome so the `2.1.x` stabilization work has explicit gates instead of relying on ad hoc manual checks.
 
 ## [2.2.3] - 2026-04-05

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "rav-landing-page",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.38.0",
         "lucide-react": "^0.563.0",
         "next": "16.1.4",
         "react": "19.2.3",
@@ -3586,6 +3587,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
+      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.38.0",
+        "motion-utils": "^12.36.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4909,6 +4937,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.38.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
+      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.36.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "indexnow:ping": "node scripts/indexnow-ping.mjs"
   },
   "dependencies": {
+    "framer-motion": "^12.38.0",
     "lucide-react": "^0.563.0",
     "next": "16.1.4",
     "react": "19.2.3",

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -88,7 +88,7 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
       </header>
 
       {/* Content */}
-      <main className="max-w-4xl mx-auto px-6 py-12">
+      <main className="max-w-3xl mx-auto px-6 py-16 md:py-20">
         <div className="docs-content">
           {children}
         </div>

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -12,42 +12,10 @@ export const metadata: Metadata = {
   description: "Complete RAV documentation for Rive Animation Viewer.",
 };
 
-const sections = [
-  { id: "getting-started", title: "Getting Started" },
-  { id: "opening-files", title: "Opening Files" },
-  { id: "ui-layout", title: "UI Layout" },
-  { id: "viewmodel-controls", title: "ViewModel Controls" },
-  { id: "artboard-switcher", title: "Artboard Switcher" },
-  { id: "consoles", title: "Consoles" },
-  { id: "export", title: "Export + Snippets" },
-  { id: "configuration", title: "Configuration" },
-  { id: "mcp", title: "MCP Integration" },
-  { id: "updates", title: "Auto Updates" },
-  { id: "shortcuts", title: "Shortcuts" },
-  { id: "troubleshooting", title: "Troubleshooting" },
-];
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-[var(--bg-void)]">
-      {/* Sidebar nav */}
-      <nav className="hidden lg:block fixed left-8 top-1/2 -translate-y-1/2 z-30">
-        <div className="flex flex-col gap-1 p-3 rounded-xl bg-[var(--bg-zinc)]/80 backdrop-blur-sm border border-[var(--border-light)]">
-          <span className="text-[10px] font-medium text-[var(--text-ghost)] uppercase tracking-wider px-2 mb-1">
-            Docs
-          </span>
-          {sections.map((section) => (
-            <Link
-              key={section.id}
-              href={asset(`/docs/${section.id}`)}
-              className="px-3 py-1.5 rounded-lg text-xs text-[var(--text-muted)] hover:text-[var(--text-white)] hover:bg-[var(--bg-void)] transition-all duration-200"
-            >
-              {section.title}
-            </Link>
-          ))}
-        </div>
-      </nav>
-
       {/* Header */}
       <header className="sticky top-0 z-40 bg-[var(--bg-void)]/90 backdrop-blur-sm border-b border-[var(--border-dark)]">
         <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -1,43 +1,90 @@
-import type { Metadata } from "next";
+"use client";
+
+import type { ReactNode } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ChevronLeft, BookOpen } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { ChevronLeft, BookOpen, ChevronRight } from "lucide-react";
 import { asset } from "@/lib/config";
 
-export const metadata: Metadata = {
-  title: {
-    template: "%s | RAV Docs",
-    default: "RAV Documentation",
-  },
-  description: "Complete RAV documentation for Rive Animation Viewer.",
-};
+const sections = [
+  { id: "getting-started", title: "Getting Started" },
+  { id: "opening-files", title: "Opening Files" },
+  { id: "ui-layout", title: "UI Layout" },
+  { id: "viewmodel-controls", title: "ViewModel Controls" },
+  { id: "artboard-switcher", title: "Artboard Switcher" },
+  { id: "consoles", title: "Consoles" },
+  { id: "export", title: "Export + Snippets" },
+  { id: "configuration", title: "Configuration" },
+  { id: "mcp", title: "MCP Integration" },
+  { id: "updates", title: "Auto Updates" },
+  { id: "shortcuts", title: "Shortcuts" },
+  { id: "troubleshooting", title: "Troubleshooting" },
+];
 
+export default function DocsLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const currentSection = sections.find((s) => pathname?.endsWith(`/docs/${s.id}`));
+  const isLanding = !currentSection;
 
-export default function DocsLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-[var(--bg-void)]">
-      {/* Header */}
+      {/* Sticky header with breadcrumb + inline TOC */}
       <header className="sticky top-0 z-40 bg-[var(--bg-void)]/90 backdrop-blur-sm border-b border-[var(--border-dark)]">
-        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center justify-between">
-          <Link
-            href={asset("/")}
-            className="flex items-center gap-2 text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors"
-          >
-            <ChevronLeft className="w-5 h-5" />
-            <span>Back to RAV</span>
-          </Link>
-          <div className="flex items-center gap-3">
+        <div className="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2 text-sm">
+            <Link
+              href={asset("/")}
+              className="text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors"
+            >
+              RAV
+            </Link>
+            <ChevronRight className="w-3 h-3 text-[var(--text-ghost)]" />
+            <Link
+              href={asset("/docs")}
+              className={`transition-colors ${isLanding ? "text-[var(--text-white)] font-semibold" : "text-[var(--text-muted)] hover:text-[var(--text-white)]"}`}
+            >
+              Docs
+            </Link>
+            {currentSection && (
+              <>
+                <ChevronRight className="w-3 h-3 text-[var(--text-ghost)]" />
+                <span className="text-[var(--text-white)] font-semibold">{currentSection.title}</span>
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
             <Image
               src={asset("/images/app-icon.png")}
               alt="RAV"
-              width={32}
-              height={32}
-              className="rounded-lg"
+              width={24}
+              height={24}
+              className="rounded-md"
             />
-            <BookOpen className="w-5 h-5 text-[var(--neon)]" />
-            <span className="font-semibold text-[var(--text-white)]">Documentation</span>
+            <BookOpen className="w-4 h-4 text-[var(--neon)]" />
           </div>
         </div>
+
+        {/* Inline scrollable TOC — only on sub-pages */}
+        {!isLanding && (
+          <div className="border-t border-[var(--border-dark)] overflow-x-auto scrollbar-none">
+            <div className="max-w-5xl mx-auto px-6 flex items-center gap-1 py-1.5">
+              {sections.map((section) => (
+                <Link
+                  key={section.id}
+                  href={asset(`/docs/${section.id}`)}
+                  className={`flex-shrink-0 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors ${
+                    currentSection?.id === section.id
+                      ? "bg-[var(--neon-dim)] text-[var(--neon)]"
+                      : "text-[var(--text-muted)] hover:text-[var(--text-white)] hover:bg-[var(--bg-elevated)]"
+                  }`}
+                >
+                  {section.title}
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
       </header>
 
       {/* Content */}

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -92,6 +92,29 @@ export default function DocsLayout({ children }: { children: ReactNode }) {
         <div className="docs-content">
           {children}
         </div>
+
+        {/* Prev / Next navigation */}
+        {currentSection && (() => {
+          const idx = sections.findIndex((s) => s.id === currentSection.id);
+          const prev = idx > 0 ? sections[idx - 1] : null;
+          const next = idx < sections.length - 1 ? sections[idx + 1] : null;
+          return (
+            <div className="flex items-center justify-between mt-16 pt-8 border-t border-[var(--border-dark)]">
+              {prev ? (
+                <Link href={asset(`/docs/${prev.id}`)} className="group flex items-center gap-2 text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors">
+                  <ChevronLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
+                  <span>{prev.title}</span>
+                </Link>
+              ) : <span />}
+              {next ? (
+                <Link href={asset(`/docs/${next.id}`)} className="group flex items-center gap-2 text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors">
+                  <span>{next.title}</span>
+                  <ChevronRight className="w-4 h-4 group-hover:translate-x-0.5 transition-transform" />
+                </Link>
+              ) : <span />}
+            </div>
+          );
+        })()}
       </main>
 
       {/* Footer */}

--- a/web/src/app/docs/mcp/page.tsx
+++ b/web/src/app/docs/mcp/page.tsx
@@ -94,14 +94,6 @@ export default function McpIntegration() {
         <strong> Script Access</strong> in the MCP Setup dialog to unlock <code>rav_eval</code>,
         <code>rav_console_exec</code>, and <code>rav_apply_code</code>.
       </p>
-
-      <h2>About Window</h2>
-      <Image src={asset("/docs/about-window.webp")} alt="About window showing build matrix, credits, dependencies, and links" width={600} height={400} className="rounded-xl border border-[var(--border-dark)] my-4" />
-      <p>
-        Desktop builds include a custom About window accessible from the Settings popover
-        or the native Help menu. It shows build metadata, runtime version, credits, links,
-        and dependency inventory.
-      </p>
     </>
   );
 }

--- a/web/src/app/docs/mcp/page.tsx
+++ b/web/src/app/docs/mcp/page.tsx
@@ -58,7 +58,7 @@ export default function McpIntegration() {
         <li><strong>Manual snippets</strong> &mdash; copy-paste configurations for any MCP client</li>
       </ul>
 
-      <h2>Available Tools (32)</h2>
+      <h2>Available Tools (36)</h2>
       <table>
         <thead><tr><th>Tool</th><th>Description</th></tr></thead>
         <tbody>
@@ -77,13 +77,17 @@ export default function McpIntegration() {
           <tr><td><code>rav_set_layout</code></td><td>Set layout fit mode</td></tr>
           <tr><td><code>rav_set_canvas_color</code></td><td>Set background color</td></tr>
           <tr><td><code>rav_set_canvas_size</code></td><td>Set canvas sizing mode, dimensions, and aspect lock</td></tr>
-          <tr><td><code>rav_export_demo</code></td><td>Export standalone HTML demo</td></tr>
+          <tr><td><code>rav_export_demo</code></td><td>Export standalone HTML demo (programmatic, no dialog)</td></tr>
+          <tr><td><code>rav_export_demo_visual</code></td><td>Visibly orchestrate the export dialog (selection, package, snippet mode) and save &mdash; for screen recordings or non-default selections</td></tr>
           <tr><td><code>generate_web_instantiation_code</code></td><td>Generate canonical web snippet with helpers and control values</td></tr>
           <tr><td><code>rav_toggle_instantiation_controls_dialog</code></td><td>Open/close the export controls dialog</td></tr>
           <tr><td><code>rav_configure_workspace</code></td><td>Set sidebar visibility, live source mode, and VM Explorer state</td></tr>
           <tr><td><code>rav_get_sm_inputs</code> / <code>rav_set_sm_input</code></td><td>State machine input access</td></tr>
           <tr><td><code>rav_eval</code></td><td>Evaluate JS in browser context (Script Access required)</td></tr>
-          <tr><td><code>rav_console_open</code> / <code>rav_console_close</code></td><td>Toggle the JS console panel</td></tr>
+          <tr><td><code>rav_console_open</code> / <code>rav_console_close</code></td><td>Toggle the bottom console panel. <code>open</code> accepts optional <code>mode</code>, <code>level</code>, <code>sources</code>, and <code>search</code> to apply a filter on open</td></tr>
+          <tr><td><code>rav_console_set_mode</code></td><td>Flip between Event Console, JS REPL, or closed without re-opening</td></tr>
+          <tr><td><code>rav_console_set_filter</code></td><td>Drive the on-screen filter toggles: <code>level</code> for JS, <code>sources</code> for Events, plus <code>search</code> on either</td></tr>
+          <tr><td><code>rav_console_clear</code></td><td>Clear the visible transcript of the active mode (or a specified mode); panel stays open</td></tr>
           <tr><td><code>rav_console_read</code> / <code>rav_console_exec</code></td><td>Read console output or run REPL code (exec requires Script Access)</td></tr>
         </tbody>
       </table>

--- a/web/src/app/docs/mcp/page.tsx
+++ b/web/src/app/docs/mcp/page.tsx
@@ -21,7 +21,26 @@ export default function McpIntegration() {
         brightens when a client is actively connected.
       </p>
 
-      <Image src={asset("/docs/mcp-indicators.webp")} alt="MCP indicator in three states: connected, idle, disabled" width={300} height={100} className="rounded-lg border border-[var(--border-dark)] my-4" />
+      {/* Editorial: indicators left, legend right */}
+      <div className="flex flex-col md:flex-row gap-6 my-6">
+        <div className="md:w-2/5 flex-shrink-0">
+          <Image src={asset("/docs/mcp-indicators.webp")} alt="MCP indicator in three states" width={300} height={100} className="rounded-lg border border-[var(--border-dark)] w-full" />
+        </div>
+        <div className="md:w-3/5 flex flex-col justify-center gap-2">
+          <div className="flex gap-2 items-start">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">1</span>
+            <p className="text-sm text-[var(--text-dim)]"><strong className="text-[var(--text-white)]">Connected</strong> &mdash; bright indigo, client actively communicating</p>
+          </div>
+          <div className="flex gap-2 items-start">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">2</span>
+            <p className="text-sm text-[var(--text-dim)]"><strong className="text-[var(--text-white)]">Idle</strong> &mdash; dim indigo, bridge ready but no active client</p>
+          </div>
+          <div className="flex gap-2 items-start">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">3</span>
+            <p className="text-sm text-[var(--text-dim)]"><strong className="text-[var(--text-white)]">Disabled</strong> &mdash; red with strikethrough, bridge stopped</p>
+          </div>
+        </div>
+      </div>
 
       <h2>Setup</h2>
 

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -19,7 +19,7 @@ const topics = [
   { icon: Terminal, title: "Consoles", desc: "Event log and JavaScript REPL", href: "/docs/consoles" },
   { icon: FileCode, title: "Export + Snippets", desc: "Standalone HTML and instantiation code", href: "/docs/export" },
   { icon: Settings, title: "Configuration", desc: "Editor modes, renderer, runtime, canvas sizing", href: "/docs/configuration" },
-  { icon: Cable, title: "MCP Integration", desc: "32 tools, bundled sidecar, Script Access", href: "/docs/mcp" },
+  { icon: Cable, title: "MCP Integration", desc: "36 tools, bundled sidecar, Script Access", href: "/docs/mcp" },
   { icon: RefreshCw, title: "Auto Updates", desc: "Built-in updater flow", href: "/docs/updates" },
   { icon: Keyboard, title: "Keyboard Shortcuts", desc: "All implemented keybindings", href: "/docs/shortcuts" },
   { icon: HelpCircle, title: "Troubleshooting", desc: "Common issues and fixes", href: "/docs/troubleshooting" },

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -28,7 +28,7 @@ const topics = [
 export default function DocsLanding() {
   return (
     <>
-      <section className="text-center mb-12">
+      <section className="text-center mb-12 pt-4">
         <h1 className="text-4xl font-bold text-[var(--text-white)] mb-4">RAV Documentation</h1>
         <p className="text-lg text-[var(--text-dim)] max-w-2xl mx-auto">
           Complete guide to Rive Animation Viewer — from installation to MCP remote control.

--- a/web/src/app/docs/ui-layout/page.tsx
+++ b/web/src/app/docs/ui-layout/page.tsx
@@ -8,17 +8,26 @@ export default function UiLayout() {
     <>
       <h1>UI Layout</h1>
 
-      <Image src={asset("/docs/ui-overview.webp")} alt="RAV full application layout with numbered callouts" width={960} height={600} className="rounded-xl border border-[var(--border-dark)] mb-4" />
+      {/* Hero overview — full width with callout legend below */}
+      <Image src={asset("/docs/ui-overview.webp")} alt="RAV full application layout with numbered callouts" width={960} height={600} className="rounded-xl border border-[var(--border-dark)] w-full mb-4" />
 
-      <ol className="text-sm text-[var(--text-dim)] mb-6 list-none pl-0 flex flex-wrap gap-x-6 gap-y-1">
-        <li><strong className="text-[var(--neon)]">1</strong> Top toolbar &mdash; playback, renderer, fit, alignment</li>
-        <li><strong className="text-[var(--neon)]">2</strong> Script editor with live-source indicator</li>
-        <li><strong className="text-[var(--neon)]">3</strong> Animation canvas (drop zone)</li>
-        <li><strong className="text-[var(--neon)]">4</strong> Event / JS console</li>
-        <li><strong className="text-[var(--neon)]">5</strong> Properties panel (VM controls, artboard switcher)</li>
-      </ol>
-
-      <p>RAV uses a three-panel layout optimized for animation inspection:</p>
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-8">
+        {[
+          { n: 1, label: "Toolbar", desc: "Playback, renderer, fit, alignment" },
+          { n: 2, label: "Script Editor", desc: "CodeMirror with live-source indicator" },
+          { n: 3, label: "Canvas", desc: "Animation viewport and drop zone" },
+          { n: 4, label: "Console", desc: "Event log or JavaScript REPL" },
+          { n: 5, label: "Properties", desc: "VM controls, artboard switcher" },
+        ].map((item) => (
+          <div key={item.n} className="flex items-start gap-2 p-2 rounded-lg bg-[var(--bg-zinc)] border border-[var(--border-dark)]">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">{item.n}</span>
+            <div>
+              <span className="text-xs font-semibold text-[var(--text-white)] block">{item.label}</span>
+              <span className="text-[10px] text-[var(--text-muted)]">{item.desc}</span>
+            </div>
+          </div>
+        ))}
+      </div>
 
       <h2>Top Toolbar</h2>
       <p>The toolbar is split into three clusters:</p>
@@ -28,34 +37,38 @@ export default function UiLayout() {
         <li><strong>Right</strong> &mdash; <strong>EXPORT</strong>, Settings gear, and MCP Setup (cable icon)</li>
       </ul>
 
-      <h2>Left Panel &mdash; Script Editor</h2>
-      <p>
-        An optional panel with a CodeMirror 6 editor for writing JavaScript configuration
-        objects. The <strong>EDITOR</strong> title block doubles as the live-source indicator:
-        neutral outline means internal wiring is active, green with a pulsing dot means the
-        applied editor config is driving the runtime.
-      </p>
+      <h2>Script Editor</h2>
 
-      <Image src={asset("/docs/editor-live-states.webp")} alt="Editor header in internal (1) and editor-active (2) states" width={400} height={60} className="rounded-lg border border-[var(--border-dark)] my-4" />
+      {/* Editorial: editor states image left, explanation right */}
+      <div className="flex flex-col md:flex-row gap-6 my-6">
+        <div className="md:w-2/5 flex-shrink-0">
+          <Image src={asset("/docs/editor-live-states.webp")} alt="Editor header in internal and editor-active states" width={400} height={60} className="rounded-lg border border-[var(--border-dark)] w-full" />
+        </div>
+        <div className="md:w-3/5 flex flex-col justify-center gap-3">
+          <div className="flex gap-2 items-start">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">1</span>
+            <p className="text-sm text-[var(--text-dim)]"><strong className="text-[var(--text-white)]">Internal mode</strong> &mdash; neutral outline, RAV&apos;s built-in wiring is active</p>
+          </div>
+          <div className="flex gap-2 items-start">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#3b82f6] text-white text-[10px] font-bold flex items-center justify-center">2</span>
+            <p className="text-sm text-[var(--text-dim)]"><strong className="text-[var(--text-white)]">Editor mode</strong> &mdash; green pulsing dot, applied editor config is driving the runtime</p>
+          </div>
+        </div>
+      </div>
 
-      <ol className="text-sm text-[var(--text-dim)] mb-4 list-none pl-0 flex gap-x-6">
-        <li><strong className="text-[var(--neon)]">1</strong> Internal mode &mdash; neutral outline, RAV wiring active</li>
-        <li><strong className="text-[var(--neon)]">2</strong> Editor mode &mdash; green pulsing dot, applied config is live</li>
-      </ol>
-
-      <h2>Center Panel &mdash; Canvas</h2>
+      <h2>Canvas</h2>
       <p>
         The primary animation viewport. Renders the loaded Rive animation with the selected
         renderer (Canvas or WebGL2). Fit and alignment are controlled from the main toolbar.
       </p>
 
-      <h2>Right Panel &mdash; Properties</h2>
+      <h2>Properties Panel</h2>
       <p>
         Contains the Artboard/Animation switcher, ViewModel controls, and state machine inputs.
         Resizable by dragging the divider, collapsible entirely.
       </p>
 
-      <h2>Bottom Panel &mdash; Console</h2>
+      <h2>Console</h2>
       <p>
         Collapsible panel with two modes: Event Console and JavaScript Console. Both share
         newest-first ordering, timestamps, follow mode, and outlined action buttons (FOLLOW,

--- a/web/src/app/docs/ui-layout/page.tsx
+++ b/web/src/app/docs/ui-layout/page.tsx
@@ -81,6 +81,20 @@ export default function UiLayout() {
         indicator, console toggle, runtime version, loaded file, update status, and playback
         state with structured iconography.
       </p>
+
+      <h2>About Window</h2>
+      <div className="flex flex-col md:flex-row gap-6 my-6">
+        <div className="md:w-3/5 flex-shrink-0">
+          <Image src={asset("/docs/about-window.webp")} alt="About window with build matrix, credits, dependencies, and links" width={600} height={400} className="rounded-xl border border-[var(--border-dark)] w-full" />
+        </div>
+        <div className="md:w-2/5 flex flex-col justify-center">
+          <p className="text-sm text-[var(--text-dim)] leading-relaxed">
+            Desktop builds include a custom About window accessible from the Settings
+            popover or the native Help menu. It surfaces build metadata, runtime version,
+            credits, product links, and a scrollable dependency inventory.
+          </p>
+        </div>
+      </div>
     </>
   );
 }

--- a/web/src/app/docs/ui-layout/page.tsx
+++ b/web/src/app/docs/ui-layout/page.tsx
@@ -8,7 +8,15 @@ export default function UiLayout() {
     <>
       <h1>UI Layout</h1>
 
-      <Image src={asset("/docs/ui-overview.webp")} alt="RAV full application layout with numbered callouts" width={960} height={600} className="rounded-xl border border-[var(--border-dark)] mb-6" />
+      <Image src={asset("/docs/ui-overview.webp")} alt="RAV full application layout with numbered callouts" width={960} height={600} className="rounded-xl border border-[var(--border-dark)] mb-4" />
+
+      <ol className="text-sm text-[var(--text-dim)] mb-6 list-none pl-0 flex flex-wrap gap-x-6 gap-y-1">
+        <li><strong className="text-[var(--neon)]">1</strong> Top toolbar &mdash; playback, renderer, fit, alignment</li>
+        <li><strong className="text-[var(--neon)]">2</strong> Script editor with live-source indicator</li>
+        <li><strong className="text-[var(--neon)]">3</strong> Animation canvas (drop zone)</li>
+        <li><strong className="text-[var(--neon)]">4</strong> Event / JS console</li>
+        <li><strong className="text-[var(--neon)]">5</strong> Properties panel (VM controls, artboard switcher)</li>
+      </ol>
 
       <p>RAV uses a three-panel layout optimized for animation inspection:</p>
 
@@ -29,6 +37,11 @@ export default function UiLayout() {
       </p>
 
       <Image src={asset("/docs/editor-live-states.webp")} alt="Editor header in internal (1) and editor-active (2) states" width={400} height={60} className="rounded-lg border border-[var(--border-dark)] my-4" />
+
+      <ol className="text-sm text-[var(--text-dim)] mb-4 list-none pl-0 flex gap-x-6">
+        <li><strong className="text-[var(--neon)]">1</strong> Internal mode &mdash; neutral outline, RAV wiring active</li>
+        <li><strong className="text-[var(--neon)]">2</strong> Editor mode &mdash; green pulsing dot, applied config is live</li>
+      </ol>
 
       <h2>Center Panel &mdash; Canvas</h2>
       <p>

--- a/web/src/app/docs/viewmodel-controls/page.tsx
+++ b/web/src/app/docs/viewmodel-controls/page.tsx
@@ -13,12 +13,35 @@ export default function ViewModelControls() {
         as native controls in the right panel.
       </p>
 
-      <Image src={asset("/docs/vm-controls-panel.webp")} alt="Properties panel showing ViewModel and state machine controls with numbered callouts" width={400} height={900} className="rounded-xl border border-[var(--border-dark)] my-4" />
-
-      <ol className="text-sm text-[var(--text-dim)] mb-6 list-none pl-0 flex flex-col gap-1">
-        <li><strong className="text-[var(--neon)]">1</strong> ViewModel section &mdash; enum dropdowns, number inputs, boolean checkboxes, color picker with alpha, string inputs, collapsible nested instances</li>
-        <li><strong className="text-[var(--neon)]">2</strong> State Machine section &mdash; boolean inputs discovered from the active state machine</li>
-      </ol>
+      {/* Editorial layout: image left, callout legend right */}
+      <div className="flex flex-col md:flex-row gap-6 my-8">
+        <div className="md:w-1/2 flex-shrink-0">
+          <Image src={asset("/docs/vm-controls-panel.webp")} alt="Properties panel showing ViewModel and state machine controls" width={400} height={900} className="rounded-xl border border-[var(--border-dark)] w-full" />
+        </div>
+        <div className="md:w-1/2 flex flex-col justify-center gap-4">
+          <div className="flex gap-3 items-start">
+            <span className="flex-shrink-0 w-7 h-7 rounded-full bg-[#3b82f6] text-white text-xs font-bold flex items-center justify-center">1</span>
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--text-white)] mb-1">ViewModel Section</h3>
+              <p className="text-xs text-[var(--text-dim)] leading-relaxed">
+                Enum dropdowns, number inputs, boolean checkboxes, color picker with alpha slider,
+                string inputs, and collapsible nested VM instances &mdash; all auto-discovered from
+                the loaded animation.
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-3 items-start">
+            <span className="flex-shrink-0 w-7 h-7 rounded-full bg-[#3b82f6] text-white text-xs font-bold flex items-center justify-center">2</span>
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--text-white)] mb-1">State Machine Section</h3>
+              <p className="text-xs text-[var(--text-dim)] leading-relaxed">
+                Boolean, number, and trigger inputs discovered from the active state machine,
+                synchronized with the running runtime.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <h2>Supported Input Types</h2>
       <table>

--- a/web/src/app/docs/viewmodel-controls/page.tsx
+++ b/web/src/app/docs/viewmodel-controls/page.tsx
@@ -13,7 +13,12 @@ export default function ViewModelControls() {
         as native controls in the right panel.
       </p>
 
-      <Image src={asset("/docs/vm-controls-panel.webp")} alt="Properties panel showing ViewModel and state machine controls with numbered callouts" width={400} height={900} className="rounded-xl border border-[var(--border-dark)] my-6" />
+      <Image src={asset("/docs/vm-controls-panel.webp")} alt="Properties panel showing ViewModel and state machine controls with numbered callouts" width={400} height={900} className="rounded-xl border border-[var(--border-dark)] my-4" />
+
+      <ol className="text-sm text-[var(--text-dim)] mb-6 list-none pl-0 flex flex-col gap-1">
+        <li><strong className="text-[var(--neon)]">1</strong> ViewModel section &mdash; enum dropdowns, number inputs, boolean checkboxes, color picker with alpha, string inputs, collapsible nested instances</li>
+        <li><strong className="text-[var(--neon)]">2</strong> State Machine section &mdash; boolean inputs discovered from the active state machine</li>
+      </ol>
 
       <h2>Supported Input Types</h2>
       <table>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -125,8 +125,8 @@ body {
 .delay-400 { animation-delay: 400ms; }
 .delay-500 { animation-delay: 500ms; }
 
-/* Global easing */
-* {
+/* Scoped easing — only on elements that actually transition */
+a, button, [class*="transition"], [class*="hover:"] {
   transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 }
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -90,6 +90,11 @@ body {
 }
 
 /* Animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;
@@ -211,25 +216,32 @@ a, button, [class*="transition"], [class*="hover:"] {
   text-decoration: underline;
 }
 
-/* Docs content styling */
+/* ── Docs content ────────────────────────────────────────── */
+
 .docs-content {
   color: var(--text-dim);
-  line-height: 1.8;
+  font-size: 0.9375rem;
+  line-height: 1.85;
+  max-width: 720px;
 }
 
 .docs-content h1 {
-  display: none;
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+  font-weight: 800;
+  color: var(--text-white);
+  letter-spacing: -0.02em;
+  margin-bottom: 2rem;
+  line-height: 1.2;
 }
 
 .docs-content h2 {
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   font-weight: 700;
   color: var(--text-white);
-  margin-top: 3rem;
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--border-light);
-  scroll-margin-top: 5rem;
+  letter-spacing: -0.01em;
+  margin-top: 3.5rem;
+  margin-bottom: 1rem;
+  scroll-margin-top: 6rem;
 }
 
 .docs-content h2:first-of-type {
@@ -237,20 +249,21 @@ a, button, [class*="transition"], [class*="hover:"] {
 }
 
 .docs-content h3 {
-  font-size: 1.125rem;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--text-white);
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-top: 2.5rem;
+  margin-bottom: 0.75rem;
 }
 
 .docs-content p {
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
 }
 
 .docs-content a {
   color: var(--neon);
   text-decoration: none;
+  text-underline-offset: 3px;
 }
 
 .docs-content a:hover {
@@ -258,12 +271,12 @@ a, button, [class*="transition"], [class*="hover:"] {
 }
 
 .docs-content ul, .docs-content ol {
-  margin-bottom: 1rem;
-  padding-left: 1.5rem;
+  margin-bottom: 1.25rem;
+  padding-left: 1.25rem;
 }
 
 .docs-content li {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.6rem;
 }
 
 .docs-content ul li {
@@ -275,57 +288,68 @@ a, button, [class*="transition"], [class*="hover:"] {
 }
 
 .docs-content blockquote {
-  border-left: 3px solid var(--neon);
-  padding-left: 1rem;
-  margin: 1.5rem 0;
+  border-left: 2px solid var(--neon);
+  margin: 2rem 0;
   color: var(--text-muted);
   background: var(--bg-zinc);
-  padding: 1rem 1rem 1rem 1.5rem;
+  padding: 1rem 1.25rem;
   border-radius: 0 0.5rem 0.5rem 0;
+  font-size: 0.875rem;
 }
 
 .docs-content code {
   background: var(--bg-elevated);
-  padding: 0.125rem 0.375rem;
+  padding: 0.15rem 0.4rem;
   border-radius: 0.25rem;
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
   font-family: "Space Mono", monospace;
   color: var(--neon);
 }
 
 .docs-content pre {
   background: var(--bg-zinc);
-  border: 1px solid var(--border-light);
-  border-radius: 0.5rem;
-  padding: 1rem;
+  border: 1px solid var(--border-dark);
+  border-radius: 0.625rem;
+  padding: 1.25rem;
   overflow-x: auto;
-  margin-bottom: 1rem;
+  margin: 1.5rem 0;
+  font-size: 0.8125rem;
+  line-height: 1.7;
 }
 
 .docs-content pre code {
   background: transparent;
   padding: 0;
+  font-size: inherit;
 }
 
 .docs-content table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 1.5rem;
-  background: var(--bg-zinc);
-  border-radius: 0.5rem;
-  overflow: hidden;
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
 }
 
 .docs-content th, .docs-content td {
-  padding: 0.75rem 1rem;
+  padding: 0.625rem 0.875rem;
   text-align: left;
-  border-bottom: 1px solid var(--border-light);
+  border-bottom: 1px solid var(--border-dark);
 }
 
 .docs-content th {
-  background: var(--bg-elevated);
-  color: var(--text-white);
+  color: var(--text-muted);
   font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.docs-content td {
+  color: var(--text-dim);
+}
+
+.docs-content td code {
+  font-size: 0.75rem;
 }
 
 .docs-content tr:last-child td {
@@ -339,6 +363,11 @@ a, button, [class*="transition"], [class*="hover:"] {
 
 .docs-content hr {
   border: none;
-  border-top: 1px solid var(--border-light);
-  margin: 2rem 0;
+  border-top: 1px solid var(--border-dark);
+  margin: 3rem 0;
+}
+
+.docs-content img {
+  border-radius: 0.625rem;
+  border: 1px solid var(--border-dark);
 }

--- a/web/src/components/AnswerSection.tsx
+++ b/web/src/components/AnswerSection.tsx
@@ -4,18 +4,17 @@ export default function AnswerSection() {
       <div className="rounded-2xl border border-[var(--border-dark)] bg-[var(--bg-zinc)] p-6 md:p-8 flex flex-col gap-6">
         <div>
           <p className="text-xs uppercase tracking-[0.14em] text-[var(--neon)] font-semibold mb-3">
-            What is RAV?
+            Why RAV
           </p>
           <h2 className="text-3xl font-bold text-[var(--text-white)] mb-3">
-            The missing desktop companion for Rive
+            Test runtime behavior without standing up a web project
           </h2>
           <p className="text-[var(--text-dim)] leading-relaxed max-w-[720px]">
-            Rive files are designed in the browser, but testing them against real runtime
-            behavior requires a dedicated tool. RAV opens any <code>.riv</code> file, binds
-            its ViewModel, activates its state machines, and gives you live controls for
-            every property &mdash; without writing a single line of integration code.
-            When you&apos;re ready to ship, RAV generates the exact instantiation snippet
-            your codebase needs.
+            Rive files are designed in the browser editor, but verifying how they behave
+            in a real runtime &mdash; with ViewModels bound, state machines running, and
+            controls responding &mdash; requires integration code. RAV removes that step.
+            Open the <code>.riv</code>, inspect every property live, then export the exact
+            snippet your codebase needs.
           </p>
         </div>
 

--- a/web/src/components/AnswerSection.tsx
+++ b/web/src/components/AnswerSection.tsx
@@ -1,50 +1,26 @@
+"use client";
+
+import ScrollReveal from "./ScrollReveal";
+
 export default function AnswerSection() {
   return (
-    <section className="w-full max-w-[1200px] px-8 py-12">
-      <div className="rounded-2xl border border-[var(--border-dark)] bg-[var(--bg-zinc)] p-6 md:p-8 flex flex-col gap-6">
-        <div>
-          <p className="text-xs uppercase tracking-[0.14em] text-[var(--neon)] font-semibold mb-3">
-            Why RAV
-          </p>
-          <h2 className="text-3xl font-bold text-[var(--text-white)] mb-3">
-            Test runtime behavior without standing up a web project
-          </h2>
-          <p className="text-[var(--text-dim)] leading-relaxed max-w-[720px]">
-            Rive files are designed in the browser editor, but verifying how they behave
-            in a real runtime &mdash; with ViewModels bound, state machines running, and
-            controls responding &mdash; requires integration code. RAV removes that step.
-            Open the <code>.riv</code>, inspect every property live, then export the exact
-            snippet your codebase needs.
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="rounded-xl border border-[var(--border-dark)] bg-[var(--bg-void)] p-5 flex flex-col gap-2">
-            <span className="text-2xl font-bold text-[var(--neon)]">32</span>
-            <span className="text-sm font-semibold text-[var(--text-white)]">MCP Tools</span>
-            <span className="text-xs text-[var(--text-muted)] leading-relaxed">
-              Open files, inspect ViewModels, drive playback, edit scripts, generate snippets,
-              and export demos &mdash; all from Claude, Codex, or any MCP client.
-            </span>
-          </div>
-          <div className="rounded-xl border border-[var(--border-dark)] bg-[var(--bg-void)] p-5 flex flex-col gap-2">
-            <span className="text-2xl font-bold text-[var(--neon)]">6</span>
-            <span className="text-sm font-semibold text-[var(--text-white)]">Control Types</span>
-            <span className="text-xs text-[var(--text-muted)] leading-relaxed">
-              Boolean, number, string, enum, color, and trigger inputs auto-discovered
-              from ViewModels and state machines with live two-way sync.
-            </span>
-          </div>
-          <div className="rounded-xl border border-[var(--border-dark)] bg-[var(--bg-void)] p-5 flex flex-col gap-2">
-            <span className="text-2xl font-bold text-[var(--neon)]">3</span>
-            <span className="text-sm font-semibold text-[var(--text-white)]">Platforms</span>
-            <span className="text-xs text-[var(--text-muted)] leading-relaxed">
-              macOS Apple Silicon, macOS Intel, and Windows 64-bit with signed releases,
-              auto-updates, and native window chrome.
-            </span>
-          </div>
-        </div>
-      </div>
+    <section className="w-full max-w-[900px] px-8 py-24 mx-auto">
+      <ScrollReveal>
+        <p className="font-mono text-xs tracking-[0.2em] uppercase text-[var(--neon)] mb-6">
+          Why this exists
+        </p>
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.75rem)] font-bold text-[var(--text-white)] leading-[1.15] mb-6">
+          Rive files are designed in the browser.
+          <br />
+          <span className="text-[var(--text-muted)]">Testing them shouldn&apos;t require a web project.</span>
+        </h2>
+        <p className="text-base text-[var(--text-dim)] leading-relaxed max-w-[640px]">
+          RAV connects directly to the Rive runtime, auto-discovers every ViewModel property
+          and state machine input, and gives you live controls without scaffolding.
+          When the animation is ready, export the exact instantiation code your app needs &mdash;
+          or let an AI agent drive the whole workflow through MCP.
+        </p>
+      </ScrollReveal>
     </section>
   );
 }

--- a/web/src/components/DownloadSection.tsx
+++ b/web/src/components/DownloadSection.tsx
@@ -1,111 +1,63 @@
 import { getLatestRelease, formatBytes } from "@/lib/github";
-import { Apple, Monitor, Download, ExternalLink } from "lucide-react";
+import { Apple, Monitor, ExternalLink } from "lucide-react";
 
 export default async function DownloadSection() {
   const release = await getLatestRelease();
-
   const macSilicon = release?.downloads.find(d => d.platform === 'mac-silicon');
   const macIntel = release?.downloads.find(d => d.platform === 'mac-intel');
   const windows = release?.downloads.find(d => d.platform === 'windows');
 
-  const platforms = [
-    macSilicon ? {
-      icon: Apple,
-      label: "macOS",
-      subtitle: "Apple Silicon",
-      chip: ".dmg",
-      size: formatBytes(macSilicon.size),
-      url: macSilicon.url,
-    } : null,
-    macIntel ? {
-      icon: Apple,
-      label: "macOS",
-      subtitle: "Intel",
-      chip: ".dmg",
-      size: formatBytes(macIntel.size),
-      url: macIntel.url,
-    } : null,
-    windows ? {
-      icon: Monitor,
-      label: "Windows",
-      subtitle: "x64",
-      chip: ".msi",
-      size: formatBytes(windows.size),
-      url: windows.url,
-    } : null,
-  ].filter(Boolean);
-
   return (
-    <section id="downloads" className="flex flex-col items-center gap-12 py-24 px-8 bg-[var(--bg-zinc)] w-full">
-      <div className="flex flex-col items-center gap-4">
-        <span className="font-mono text-xs font-medium tracking-[3px] uppercase text-[var(--neon)]">
-          Downloads
-        </span>
-        <h2 className="font-sans font-bold text-4xl text-[var(--text-white)]">
-          Get RAV
+    <section id="downloads" className="relative w-full py-24 px-8 overflow-hidden">
+      {/* Atmospheric glow */}
+      <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[600px] h-[400px] rounded-full bg-[#C4F82A] opacity-[0.03] blur-[100px] pointer-events-none" />
+
+      <div className="relative z-10 max-w-[700px] mx-auto text-center">
+        <p className="font-mono text-xs tracking-[0.2em] uppercase text-[var(--neon)] mb-4">
+          Download
+        </p>
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.75rem)] font-bold text-[var(--text-white)] leading-[1.15] mb-3">
+          Ready when you are
         </h2>
-        {release && (
-          <div className="flex items-center gap-3">
-            <span className="px-2.5 py-1 rounded-md bg-[var(--neon-dim)] border border-[var(--neon-glow)] font-mono text-xs text-[var(--neon)]">
-              v{release.version}
-            </span>
-            <span className="text-sm text-[var(--text-muted)]">
-              {new Date(release.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
-            </span>
-          </div>
-        )}
-      </div>
+        <p className="text-base text-[var(--text-muted)] mb-10">
+          Free, open source, and shipping for macOS and Windows.
+        </p>
 
-      {/* Platform Cards */}
-      <div className="flex flex-col sm:flex-row gap-6 max-w-[900px] w-full justify-center">
-        {platforms.map((platform) => platform && (
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-6">
           <a
-            key={platform.subtitle}
-            href={platform.url}
-            className="group flex flex-col items-center gap-4 p-8 rounded-2xl bg-[var(--bg-void)] border border-[var(--border-dark)] hover:border-[var(--neon)] hover:shadow-[0_0_40px_var(--neon-glow)] transition-all duration-300 flex-1 min-w-[240px]"
+            href={macSilicon?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
+            className="flex items-center gap-2.5 px-6 py-3 rounded-lg btn-neon text-sm font-semibold hover:shadow-[0_0_32px_var(--neon-glow)] transition-shadow duration-300"
           >
-            <platform.icon className="w-8 h-8 text-[var(--text-dim)] group-hover:text-[var(--neon)] transition-colors duration-300" />
-            <div className="flex flex-col items-center gap-1">
-              <span className="text-lg font-semibold text-[var(--text-white)]">
-                {platform.label}
-              </span>
-              <span className="text-sm text-[var(--text-muted)]">
-                {platform.subtitle}
-              </span>
-            </div>
-            <span className="font-mono text-xs text-[var(--text-ghost)]">
-              {platform.chip} &middot; {platform.size}
-            </span>
-            <div className="flex items-center gap-2 px-5 py-2.5 rounded-lg btn-neon text-sm group-hover:scale-105 transition-transform duration-300">
-              <Download className="w-4 h-4" />
-              Download
-            </div>
+            <Apple className="w-4 h-4" />
+            <span>Mac &middot; Apple Silicon</span>
+            {macSilicon && <span className="text-[10px] opacity-50">{formatBytes(macSilicon.size)}</span>}
           </a>
-        ))}
-      </div>
+          <a
+            href={macIntel?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
+            className="flex items-center gap-2 px-5 py-3 rounded-lg border border-[var(--border-light)] text-sm text-[var(--text-dim)] hover:text-[var(--text-white)] hover:border-[var(--neon-glow)] transition-colors duration-300"
+          >
+            <Apple className="w-3.5 h-3.5" />
+            <span>Mac &middot; Intel</span>
+          </a>
+          <a
+            href={windows?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
+            className="flex items-center gap-2 px-5 py-3 rounded-lg border border-[var(--border-light)] text-sm text-[var(--text-dim)] hover:text-[var(--text-white)] hover:border-[var(--neon-glow)] transition-colors duration-300"
+          >
+            <Monitor className="w-3.5 h-3.5" />
+            <span>Windows</span>
+          </a>
+        </div>
 
-      {platforms.length === 0 && (
         <a
-          href="https://github.com/ivg-design/rive-animation-viewer/releases/latest"
+          href="https://github.com/ivg-design/rive-animation-viewer/releases"
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-3 px-7 py-3.5 rounded-xl btn-neon text-[15px] hover:scale-105 transition-all duration-300"
+          className="inline-flex items-center gap-1.5 text-xs text-[var(--text-ghost)] hover:text-[var(--text-muted)] transition-colors"
         >
-          <Download className="w-5 h-5" />
-          Browse Releases on GitHub
+          <ExternalLink className="w-3 h-3" />
+          All releases on GitHub
         </a>
-      )}
-
-      {/* GitHub link */}
-      <a
-        href="https://github.com/ivg-design/rive-animation-viewer/releases"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-2 text-sm text-[var(--text-muted)] hover:text-[var(--neon)] transition-colors duration-300"
-      >
-        <ExternalLink className="w-4 h-4" />
-        Or browse all releases on GitHub
-      </a>
+      </div>
     </section>
   );
 }

--- a/web/src/components/FeaturesSection.tsx
+++ b/web/src/components/FeaturesSection.tsx
@@ -34,7 +34,7 @@ const primaryFeatures = [
   {
     label: "MCP",
     title: "AI agents as co-pilots",
-    description: "A bundled native sidecar exposes 32 MCP tools. Claude, Codex, or any MCP client can open files, inspect ViewModels, drive playback, edit scripts, generate snippets, and export demos — without touching the UI. One-click install from the app.",
+    description: "A bundled native sidecar exposes 36 MCP tools. Claude, Codex, or any MCP client can open files, inspect ViewModels, drive playback, edit scripts, generate snippets, control the console panel, and export demos — without touching the UI. One-click install from the app.",
     image: "/docs/mcp-setup.webp",
     imageAlt: "MCP Setup dialog with client detection, one-click install, and snippet copy",
     imageWidth: 500,

--- a/web/src/components/FeaturesSection.tsx
+++ b/web/src/components/FeaturesSection.tsx
@@ -81,43 +81,45 @@ export default function FeaturesSection() {
     <section id="features" className="flex flex-col items-center gap-12 py-24 px-8 w-full">
       <div className="flex flex-col items-center gap-4">
         <span className="font-mono text-xs font-medium tracking-[3px] uppercase text-[var(--neon)]">
-          Features
+          Capabilities
         </span>
         <h2 className="font-sans font-bold text-4xl text-[var(--text-white)]">
-          Everything you need to inspect Rive files
+          What RAV does
         </h2>
-        <p className="text-base text-[var(--text-muted)] max-w-[600px] text-center">
-          A purpose-built desktop player for the Rive animation workflow.
-        </p>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-[1000px] w-full">
-        {features.map((feature, index) => (
-          <div
-            key={feature.title}
-            className="group relative p-4 rounded-xl bg-[var(--bg-zinc)] border border-[var(--border-dark)] hover:border-[var(--neon-glow)] hover:bg-[var(--bg-elevated)] transition-colors duration-300 opacity-0 animate-fade-in-up"
-            style={{ animationDelay: `${index * 50}ms` }}
-          >
-            {/* Static card content — never changes height */}
-            <div className="flex items-center gap-3">
-              <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--neon-dim)] group-hover:bg-[var(--neon-glow)] transition-colors duration-300 flex-shrink-0">
-                <feature.icon className="w-4 h-4 text-[var(--neon)]" />
+        {features.map((feature, index) => {
+          const isBottomRow = index >= features.length - 4;
+          return (
+            <div
+              key={feature.title}
+              className="group relative p-4 rounded-xl bg-[var(--bg-zinc)] border border-[var(--border-dark)] hover:border-[var(--neon-glow)] hover:bg-[var(--bg-elevated)] transition-colors duration-300"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--neon-dim)] group-hover:bg-[var(--neon-glow)] transition-colors duration-300 flex-shrink-0">
+                  <feature.icon className="w-4 h-4 text-[var(--neon)]" />
+                </div>
+                <h3 className="text-sm font-semibold text-[var(--text-white)] leading-tight">
+                  {feature.title}
+                </h3>
               </div>
-              <h3 className="text-sm font-semibold text-[var(--text-white)] leading-tight">
-                {feature.title}
-              </h3>
-            </div>
 
-            {/* Floating tooltip — overlays below the card, outside grid flow */}
-            <div className="pointer-events-none absolute left-0 right-0 top-full z-20 pt-1 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-200 ease-out">
-              <div className="mx-1 p-3 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-bright)] shadow-lg shadow-black/40">
-                <p className="text-xs text-[var(--text-dim)] leading-relaxed">
-                  {feature.description}
-                </p>
+              {/* Tooltip — flips upward for bottom row to prevent clipping */}
+              <div className={`pointer-events-none absolute left-0 right-0 z-20 opacity-0 group-hover:opacity-100 transition-all duration-200 ease-out ${
+                isBottomRow
+                  ? "bottom-full pb-1 translate-y-1 group-hover:translate-y-0"
+                  : "top-full pt-1 -translate-y-1 group-hover:translate-y-0"
+              }`}>
+                <div className="mx-1 p-3 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-bright)] shadow-lg shadow-black/40">
+                  <p className="text-xs text-[var(--text-dim)] leading-relaxed">
+                    {feature.description}
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/web/src/components/FeaturesSection.tsx
+++ b/web/src/components/FeaturesSection.tsx
@@ -1,126 +1,122 @@
+"use client";
+
+import Image from "next/image";
+import { asset } from "@/lib/config";
+import ScrollReveal, { ScrollRevealGroup, ScrollRevealItem } from "./ScrollReveal";
 import {
-  Gamepad2,
-  Terminal,
-  FileCode,
-  Code2,
-  MonitorCog,
-  RotateCcw,
-  Cable,
-  Layers,
-  Download,
-  Maximize,
-  MousePointerClick,
-  Search,
+  Gamepad2, Terminal, FileCode, Code2, MonitorCog, RotateCcw,
+  Cable, Layers, Download, Maximize, MousePointerClick, Search,
 } from "lucide-react";
 
-const features = [
+/* ── Primary features — editorial blocks with screenshots ── */
+
+const primaryFeatures = [
   {
-    icon: Gamepad2,
-    title: "ViewModel Controls",
-    description: "Auto-discovered booleans, numbers, strings, triggers, enums, colors, and nested hierarchies with live two-way runtime sync.",
+    label: "Controls",
+    title: "Every property, live",
+    description: "RAV reads the ViewModel hierarchy and state machine inputs from your .riv file and renders native controls — booleans, numbers, strings, enums, colors, and triggers — all synchronized with the running runtime in real time.",
+    image: "/docs/vm-controls-panel.webp",
+    imageAlt: "ViewModel controls panel showing enums, numbers, booleans, color picker, and nested instances",
+    imageWidth: 400,
+    imageHeight: 900,
+    reverse: false,
   },
   {
-    icon: Layers,
-    title: "Artboards + Playback",
-    description: "Switch artboards, animations, and state machines from exact authored names. VM controls and instances repopulate for each target.",
+    label: "Export",
+    title: "From viewer to codebase",
+    description: "Choose which controls to serialize, pick CDN or local package output, preview the generated snippet inline, and copy or export a self-contained HTML demo — all from one dialog. Fixed canvas sizes, layout modes, and artboard state carry through.",
+    image: "/docs/export-controls.webp",
+    imageAlt: "Snippet & Export Controls dialog with tree checkboxes and live code preview",
+    imageWidth: 800,
+    imageHeight: 500,
+    reverse: true,
   },
   {
-    icon: Terminal,
-    title: "Dual Consoles",
-    description: "Event Console and JavaScript REPL share newest-first transcripts, timestamps, follow mode, level filters, and copy/clear actions.",
+    label: "MCP",
+    title: "AI agents as co-pilots",
+    description: "A bundled native sidecar exposes 32 MCP tools. Claude, Codex, or any MCP client can open files, inspect ViewModels, drive playback, edit scripts, generate snippets, and export demos — without touching the UI. One-click install from the app.",
+    image: "/docs/mcp-setup.webp",
+    imageAlt: "MCP Setup dialog with client detection, one-click install, and snippet copy",
+    imageWidth: 500,
+    imageHeight: 700,
+    reverse: false,
   },
-  {
-    icon: FileCode,
-    title: "Export + Snippets",
-    description: "Standalone HTML export and canonical CDN/local instantiation snippets with per-control selection, inline preview, and live-state serialization.",
-  },
-  {
-    icon: Code2,
-    title: "Script Editor",
-    description: "CodeMirror 6 with internal-vs-editor live indication, APPLY action, and runtime re-instantiation that preserves artboard and control state.",
-  },
-  {
-    icon: MonitorCog,
-    title: "Renderer + Runtime",
-    description: "Canvas and WebGL2 on the fly. Fit, alignment, and explicit fixed canvas sizing in the toolbar. Latest, pinned, or custom runtime semver.",
-  },
-  {
-    icon: Maximize,
-    title: "Canvas Sizing",
-    description: "Pin to explicit pixel dimensions with aspect-ratio locking, or let the canvas auto-fill. Fixed sizes carry through to exports and snippets.",
-  },
-  {
-    icon: Cable,
-    title: "MCP Integration",
-    description: "Bundled native sidecar with 32 tools. One-click installs for Claude Code, Claude Desktop, and Codex. Script Access gate. Editable port.",
-  },
-  {
-    icon: RotateCcw,
-    title: "State Preservation",
-    description: "Refresh and reload flows preserve artboard, playback target, and bound control values. Reset restores captured state after re-instantiation.",
-  },
-  {
-    icon: MousePointerClick,
-    title: "State Machine Inputs",
-    description: "Auto-discovers boolean, number, and trigger inputs for state machines and keeps them synchronized with the running runtime.",
-  },
-  {
-    icon: Download,
-    title: "Auto Updates",
-    description: "Signed releases detected, downloaded, installed, and relaunched from the in-app update chip. Merged feed across all platforms.",
-  },
-  {
-    icon: Search,
-    title: "VM Explorer",
-    description: "Inject the helper snippet for vmExplore, vmGet, vmSet, vmTree, and vmPaths runtime debugging via the JavaScript console.",
-  },
+];
+
+/* ── Secondary features — compact grid ── */
+
+const secondaryFeatures = [
+  { icon: Layers, title: "Artboard switching", desc: "Switch artboards and playback targets from dropdowns. VM controls repopulate per target." },
+  { icon: Terminal, title: "Dual consoles", desc: "Event log and JavaScript REPL with timestamps, follow mode, level filters, and copy." },
+  { icon: Code2, title: "Script editor", desc: "CodeMirror 6 with live source indication. Apply config without losing artboard state." },
+  { icon: MonitorCog, title: "Renderer + runtime", desc: "Canvas or WebGL2. Latest, pinned, or custom runtime semver. Fit and alignment in the toolbar." },
+  { icon: Maximize, title: "Canvas sizing", desc: "Auto or fixed pixel dimensions with aspect lock. Carries through to exports and snippets." },
+  { icon: RotateCcw, title: "State preservation", desc: "Reset and reload preserve artboard, playback, and control values across re-instantiation." },
+  { icon: Download, title: "Auto updates", desc: "Signed releases detected, downloaded, and installed from the in-app update chip." },
+  { icon: Search, title: "VM Explorer", desc: "Inject the helper snippet for vmExplore, vmGet, vmSet, vmTree, and vmPaths debugging." },
 ];
 
 export default function FeaturesSection() {
   return (
-    <section id="features" className="flex flex-col items-center gap-12 py-24 px-8 w-full">
-      <div className="flex flex-col items-center gap-4">
-        <span className="font-mono text-xs font-medium tracking-[3px] uppercase text-[var(--neon)]">
+    <section id="features" className="flex flex-col items-center py-24 px-8 w-full">
+      {/* Section header */}
+      <ScrollReveal className="text-center mb-20 max-w-[600px]">
+        <p className="font-mono text-xs tracking-[0.2em] uppercase text-[var(--neon)] mb-4">
           Capabilities
-        </span>
-        <h2 className="font-sans font-bold text-4xl text-[var(--text-white)]">
+        </p>
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.75rem)] font-bold text-[var(--text-white)] leading-[1.15]">
           What RAV does
         </h2>
-      </div>
+      </ScrollReveal>
 
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 max-w-[1000px] w-full">
-        {features.map((feature, index) => {
-          const isBottomRow = index >= features.length - 4;
-          return (
-            <div
-              key={feature.title}
-              className="group relative p-4 rounded-xl bg-[var(--bg-zinc)] border border-[var(--border-dark)] hover:border-[var(--neon-glow)] hover:bg-[var(--bg-elevated)] transition-colors duration-300"
-            >
-              <div className="flex items-center gap-3">
-                <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--neon-dim)] group-hover:bg-[var(--neon-glow)] transition-colors duration-300 flex-shrink-0">
-                  <feature.icon className="w-4 h-4 text-[var(--neon)]" />
+      {/* Primary features — editorial alternating layout */}
+      <div className="flex flex-col gap-32 max-w-[1100px] w-full mb-32">
+        {primaryFeatures.map((feature) => (
+          <ScrollReveal key={feature.title}>
+            <div className={`flex flex-col ${feature.reverse ? "md:flex-row-reverse" : "md:flex-row"} items-center gap-12`}>
+              {/* Image */}
+              <div className="md:w-1/2 flex-shrink-0">
+                <div className="relative rounded-xl overflow-hidden border border-[var(--border-dark)] bg-[var(--bg-zinc)]">
+                  <Image
+                    src={asset(feature.image)}
+                    alt={feature.imageAlt}
+                    width={feature.imageWidth}
+                    height={feature.imageHeight}
+                    className="w-full h-auto"
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                  />
                 </div>
-                <h3 className="text-sm font-semibold text-[var(--text-white)] leading-tight">
+              </div>
+
+              {/* Text */}
+              <div className="md:w-1/2">
+                <p className="font-mono text-[11px] tracking-[0.2em] uppercase text-[var(--neon)] mb-3">
+                  {feature.label}
+                </p>
+                <h3 className="text-2xl md:text-3xl font-bold text-[var(--text-white)] mb-4 leading-tight">
                   {feature.title}
                 </h3>
-              </div>
-
-              {/* Tooltip — flips upward for bottom row to prevent clipping */}
-              <div className={`pointer-events-none absolute left-0 right-0 z-20 opacity-0 group-hover:opacity-100 transition-all duration-200 ease-out ${
-                isBottomRow
-                  ? "bottom-full pb-1 translate-y-1 group-hover:translate-y-0"
-                  : "top-full pt-1 -translate-y-1 group-hover:translate-y-0"
-              }`}>
-                <div className="mx-1 p-3 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-bright)] shadow-lg shadow-black/40">
-                  <p className="text-xs text-[var(--text-dim)] leading-relaxed">
-                    {feature.description}
-                  </p>
-                </div>
+                <p className="text-[15px] text-[var(--text-dim)] leading-relaxed">
+                  {feature.description}
+                </p>
               </div>
             </div>
-          );
-        })}
+          </ScrollReveal>
+        ))}
       </div>
+
+      {/* Secondary features — compact grid */}
+      <ScrollRevealGroup className="grid grid-cols-2 md:grid-cols-4 gap-px max-w-[1100px] w-full bg-[var(--border-dark)] rounded-xl overflow-hidden">
+        {secondaryFeatures.map((feature) => (
+          <ScrollRevealItem key={feature.title}>
+            <div className="bg-[var(--bg-void)] p-6 flex flex-col gap-3 h-full hover:bg-[var(--bg-zinc)] transition-colors duration-300">
+              <feature.icon className="w-5 h-5 text-[var(--neon)]" />
+              <h4 className="text-sm font-semibold text-[var(--text-white)]">{feature.title}</h4>
+              <p className="text-xs text-[var(--text-muted)] leading-relaxed">{feature.desc}</p>
+            </div>
+          </ScrollRevealItem>
+        ))}
+      </ScrollRevealGroup>
     </section>
   );
 }

--- a/web/src/components/GallerySection.tsx
+++ b/web/src/components/GallerySection.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import { asset } from "@/lib/config";
-import { X } from "lucide-react";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
 
 type GalleryItem = {
   src: string;
@@ -82,14 +82,33 @@ const items: GalleryItem[] = [
 export default function GallerySection() {
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
 
+  const goNext = useCallback(() => {
+    if (lightboxIndex !== null) setLightboxIndex((lightboxIndex + 1) % items.length);
+  }, [lightboxIndex]);
+
+  const goPrev = useCallback(() => {
+    if (lightboxIndex !== null) setLightboxIndex((lightboxIndex - 1 + items.length) % items.length);
+  }, [lightboxIndex]);
+
+  useEffect(() => {
+    if (lightboxIndex === null) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setLightboxIndex(null);
+      if (e.key === "ArrowRight") goNext();
+      if (e.key === "ArrowLeft") goPrev();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [lightboxIndex, goNext, goPrev]);
+
   return (
     <section id="screenshots" className="flex flex-col items-center gap-12 py-24 px-8 section-gradient w-full">
       <div className="flex flex-col items-center gap-4">
         <span className="font-mono text-xs font-medium tracking-[3px] uppercase text-[var(--neon)]">
-          Screenshots
+          Interface
         </span>
         <h2 className="font-sans font-bold text-4xl text-[var(--text-white)]">
-          See it in action
+          Interface tour
         </h2>
       </div>
 
@@ -126,6 +145,18 @@ export default function GallerySection() {
             className="absolute top-6 right-6 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
           >
             <X className="w-6 h-6 text-white" />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); goPrev(); }}
+            className="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
+          >
+            <ChevronLeft className="w-6 h-6 text-white" />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); goNext(); }}
+            className="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
+          >
+            <ChevronRight className="w-6 h-6 text-white" />
           </button>
           <div className="relative w-[90vw] h-[85vh] flex items-center justify-center">
             <Image

--- a/web/src/components/GallerySection.tsx
+++ b/web/src/components/GallerySection.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import { asset } from "@/lib/config";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import ScrollReveal from "./ScrollReveal";
 
 type GalleryItem = {
   src: string;
@@ -15,67 +16,40 @@ type GalleryItem = {
 
 const items: GalleryItem[] = [
   {
-    src: "/docs/ui-overview.webp",
-    alt: "Full RAV application layout with editor, canvas, properties panel, and console",
-    caption: "Application overview",
-    width: 1280,
-    height: 800,
-  },
-  {
-    src: "/docs/vm-controls-panel.webp",
-    alt: "Properties panel showing ViewModel controls, state machine inputs, and nested instances",
-    caption: "ViewModel controls",
-    width: 400,
-    height: 900,
-  },
-  {
     src: "/docs/event-console.webp",
-    alt: "Event console with multi-source filtering and timestamps",
-    caption: "Event console",
-    width: 800,
-    height: 200,
+    alt: "Event console with multi-source filtering",
+    caption: "Event console — filter by Native, Rive User, UI, and MCP sources",
+    width: 800, height: 200,
   },
   {
     src: "/docs/js-console.webp",
-    alt: "JavaScript console REPL with object introspection and level filters",
-    caption: "JavaScript console",
-    width: 800,
-    height: 200,
-  },
-  {
-    src: "/docs/export-controls.webp",
-    alt: "Snippet and Export Controls dialog with tree checkboxes and code preview",
-    caption: "Export controls",
-    width: 800,
-    height: 500,
+    alt: "JavaScript REPL with object introspection",
+    caption: "JavaScript console — REPL against the live runtime with object expansion",
+    width: 800, height: 200,
   },
   {
     src: "/docs/artboard-switcher.webp",
-    alt: "Artboard switcher with playback dropdown and VM instance selector",
-    caption: "Artboard switcher",
-    width: 400,
-    height: 250,
-  },
-  {
-    src: "/docs/mcp-setup.webp",
-    alt: "MCP Setup dialog with client detection and install actions",
-    caption: "MCP setup",
-    width: 500,
-    height: 700,
+    alt: "Artboard switcher with playback and instance dropdowns",
+    caption: "Artboard switcher — select artboards, playback targets, and VM instances",
+    width: 400, height: 250,
   },
   {
     src: "/docs/settings-popover.webp",
-    alt: "Settings panel with runtime version, canvas sizing, and background controls",
-    caption: "Settings panel",
-    width: 500,
-    height: 320,
+    alt: "Settings panel with runtime version and canvas sizing",
+    caption: "Settings — runtime version, canvas sizing, background controls",
+    width: 500, height: 320,
+  },
+  {
+    src: "/docs/mcp-indicators.webp",
+    alt: "MCP indicator in three states",
+    caption: "MCP status — connected, idle, and disabled states in the runtime strip",
+    width: 300, height: 100,
   },
   {
     src: "/docs/about-window.webp",
-    alt: "About window with build matrix, credits, and dependency inventory",
-    caption: "About window",
-    width: 600,
-    height: 400,
+    alt: "About window with build metadata",
+    caption: "About — build matrix, credits, dependencies, and product links",
+    width: 600, height: 400,
   },
 ];
 
@@ -85,7 +59,6 @@ export default function GallerySection() {
   const goNext = useCallback(() => {
     if (lightboxIndex !== null) setLightboxIndex((lightboxIndex + 1) % items.length);
   }, [lightboxIndex]);
-
   const goPrev = useCallback(() => {
     if (lightboxIndex !== null) setLightboxIndex((lightboxIndex - 1 + items.length) % items.length);
   }, [lightboxIndex]);
@@ -102,63 +75,55 @@ export default function GallerySection() {
   }, [lightboxIndex, goNext, goPrev]);
 
   return (
-    <section id="screenshots" className="flex flex-col items-center gap-12 py-24 px-8 section-gradient w-full">
-      <div className="flex flex-col items-center gap-4">
-        <span className="font-mono text-xs font-medium tracking-[3px] uppercase text-[var(--neon)]">
+    <section id="screenshots" className="flex flex-col items-center py-24 px-8 w-full">
+      <ScrollReveal className="text-center mb-16">
+        <p className="font-mono text-xs tracking-[0.2em] uppercase text-[var(--neon)] mb-4">
           Interface
-        </span>
-        <h2 className="font-sans font-bold text-4xl text-[var(--text-white)]">
-          Interface tour
+        </p>
+        <h2 className="text-[clamp(1.75rem,3.5vw,2.75rem)] font-bold text-[var(--text-white)] leading-[1.15]">
+          More of the app
         </h2>
-      </div>
+      </ScrollReveal>
 
-      <div className="columns-1 sm:columns-2 lg:columns-3 gap-3 max-w-[1100px] w-full">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-[1100px] w-full">
         {items.map((item, index) => (
-          <button
-            key={item.caption}
-            onClick={() => setLightboxIndex(index)}
-            className="group relative w-full mb-3 break-inside-avoid rounded-xl overflow-hidden bg-[var(--bg-zinc)] border border-[var(--border-dark)] hover:border-[var(--neon-glow)] transition-colors duration-300 cursor-pointer block"
-          >
-            <Image
-              src={asset(item.src)}
-              alt={item.alt}
-              width={item.width}
-              height={item.height}
-              className="w-full h-auto group-hover:scale-[1.02] transition-transform duration-500"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            />
-            <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300" />
-            <div className="absolute bottom-2 left-2 px-2.5 py-1 rounded-full bg-black/60 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-              <span className="text-[10px] text-white/80">{item.caption}</span>
-            </div>
-          </button>
+          <ScrollReveal key={item.caption} delay={index * 0.05}>
+            <button
+              onClick={() => setLightboxIndex(index)}
+              className="group relative w-full rounded-xl overflow-hidden bg-[var(--bg-zinc)] border border-[var(--border-dark)] hover:border-[var(--neon-glow)] transition-colors duration-300 cursor-pointer text-left"
+            >
+              <Image
+                src={asset(item.src)}
+                alt={item.alt}
+                width={item.width}
+                height={item.height}
+                className="w-full h-auto"
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              />
+              <div className="p-3 border-t border-[var(--border-dark)]">
+                <p className="text-[11px] text-[var(--text-muted)] leading-relaxed">{item.caption}</p>
+              </div>
+            </button>
+          </ScrollReveal>
         ))}
       </div>
 
+      {/* Lightbox */}
       {lightboxIndex !== null && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-sm"
           onClick={() => setLightboxIndex(null)}
         >
-          <button
-            onClick={() => setLightboxIndex(null)}
-            className="absolute top-6 right-6 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
-          >
-            <X className="w-6 h-6 text-white" />
+          <button onClick={() => setLightboxIndex(null)} className="absolute top-6 right-6 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10">
+            <X className="w-5 h-5 text-white" />
           </button>
-          <button
-            onClick={(e) => { e.stopPropagation(); goPrev(); }}
-            className="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
-          >
-            <ChevronLeft className="w-6 h-6 text-white" />
+          <button onClick={(e) => { e.stopPropagation(); goPrev(); }} className="absolute left-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10">
+            <ChevronLeft className="w-5 h-5 text-white" />
           </button>
-          <button
-            onClick={(e) => { e.stopPropagation(); goNext(); }}
-            className="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10"
-          >
-            <ChevronRight className="w-6 h-6 text-white" />
+          <button onClick={(e) => { e.stopPropagation(); goNext(); }} className="absolute right-4 top-1/2 -translate-y-1/2 p-2 rounded-full bg-white/10 hover:bg-white/20 transition-colors z-10">
+            <ChevronRight className="w-5 h-5 text-white" />
           </button>
-          <div className="relative w-[90vw] h-[85vh] flex items-center justify-center">
+          <div className="relative w-[90vw] h-[85vh] flex items-center justify-center" onClick={(e) => e.stopPropagation()}>
             <Image
               src={asset(items[lightboxIndex].src)}
               alt={items[lightboxIndex].alt}
@@ -168,8 +133,8 @@ export default function GallerySection() {
               sizes="90vw"
             />
           </div>
-          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-black/60 backdrop-blur-sm">
-            <span className="text-sm text-white/80">{items[lightboxIndex].caption}</span>
+          <div className="absolute bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg bg-black/60 backdrop-blur-sm max-w-[600px] text-center">
+            <span className="text-xs text-white/80">{items[lightboxIndex].caption}</span>
           </div>
         </div>
       )}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,70 +1,85 @@
 "use client";
 
+import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { asset } from "@/lib/config";
+import { Menu, X } from "lucide-react";
+
+const navLinks = [
+  { label: "Features", href: "#features" },
+  { label: "Interface", href: "#screenshots" },
+  { label: "Download", href: "#downloads" },
+  { label: "Changelog", href: "/changelog", internal: true },
+  { label: "Docs", href: "/docs", internal: true },
+];
 
 export default function Header() {
-  const handleNavClick = (e: React.MouseEvent<HTMLAnchorElement>, targetId: string) => {
-    e.preventDefault();
-    const element = document.getElementById(targetId);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth" });
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const scrollTo = (id: string) => {
+    setMobileOpen(false);
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth" });
+      history.replaceState(null, "", `#${id}`);
     }
   };
 
   return (
-    <header className="flex items-center justify-between px-8 md:px-20 py-4 bg-[var(--bg-void)]/90 w-full sticky top-0 z-40 backdrop-blur-sm border-b border-[var(--border-dark)] transition-all duration-300">
-      {/* Logo */}
-      <Link href={asset("/")} className="flex items-center gap-3">
-        <Image
-          src={asset("/images/app-icon.png")}
-          alt="RAV Logo"
-          width={40}
-          height={40}
-          className="rounded-xl transition-transform duration-300 hover:scale-105"
-        />
-        <span className="font-mono text-lg font-bold tracking-wider text-[var(--text-white)]">
-          RAV - Rive Animation Viewer
-        </span>
-      </Link>
+    <header className="sticky top-0 z-50 w-full border-b border-[var(--border-dark)] bg-[var(--bg-void)]/80 backdrop-blur-md">
+      <div className="max-w-[1200px] mx-auto px-6 py-3 flex items-center justify-between">
+        {/* Logo */}
+        <Link href={asset("/")} className="flex items-center gap-2.5">
+          <Image
+            src={asset("/images/app-icon.png")}
+            alt="RAV"
+            width={32}
+            height={32}
+            className="rounded-lg"
+          />
+          <span className="font-mono text-sm font-bold tracking-wider text-[var(--text-white)]">
+            RAV
+          </span>
+        </Link>
 
-      {/* Navigation */}
-      <nav className="hidden md:flex items-center gap-8">
-        <a
-          href="#features"
-          onClick={(e) => handleNavClick(e, "features")}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors duration-300"
-        >
-          Features
-        </a>
-        <a
-          href="#screenshots"
-          onClick={(e) => handleNavClick(e, "screenshots")}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors duration-300"
-        >
-          Screenshots
-        </a>
-        <a
-          href="#downloads"
-          onClick={(e) => handleNavClick(e, "downloads")}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors duration-300"
-        >
-          Downloads
-        </a>
-        <Link
-          href={asset("/changelog")}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors duration-300"
-        >
-          Changelog
-        </Link>
-        <Link
-          href={asset("/docs")}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors duration-300"
-        >
-          Docs
-        </Link>
-      </nav>
+        {/* Desktop nav */}
+        <nav className="hidden md:flex items-center gap-6">
+          {navLinks.map((link) =>
+            link.internal ? (
+              <Link key={link.label} href={asset(link.href)} className="text-[13px] text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors">
+                {link.label}
+              </Link>
+            ) : (
+              <button key={link.label} onClick={() => scrollTo(link.href.slice(1))} className="text-[13px] text-[var(--text-muted)] hover:text-[var(--text-white)] transition-colors">
+                {link.label}
+              </button>
+            )
+          )}
+        </nav>
+
+        {/* Mobile toggle */}
+        <button onClick={() => setMobileOpen(!mobileOpen)} className="md:hidden p-1.5 rounded-md text-[var(--text-muted)] hover:text-[var(--text-white)] hover:bg-[var(--bg-elevated)] transition-colors">
+          {mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+        </button>
+      </div>
+
+      {/* Mobile nav drawer */}
+      {mobileOpen && (
+        <nav className="md:hidden border-t border-[var(--border-dark)] bg-[var(--bg-void)] px-6 py-4 flex flex-col gap-3">
+          {navLinks.map((link) =>
+            link.internal ? (
+              <Link key={link.label} href={asset(link.href)} onClick={() => setMobileOpen(false)} className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] py-1.5 transition-colors">
+                {link.label}
+              </Link>
+            ) : (
+              <button key={link.label} onClick={() => scrollTo(link.href.slice(1))} className="text-sm text-[var(--text-muted)] hover:text-[var(--text-white)] py-1.5 text-left transition-colors">
+                {link.label}
+              </button>
+            )
+          )}
+        </nav>
+      )}
     </header>
   );
 }

--- a/web/src/components/HeroSection.tsx
+++ b/web/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
-import Image from "next/image";
 import { asset } from "@/lib/config";
 import { getLatestRelease, formatBytes } from "@/lib/github";
 import { Apple, Monitor } from "lucide-react";
+import InteractiveDemo from "./InteractiveDemo";
 
 export default async function HeroSection() {
   const release = await getLatestRelease();
@@ -72,20 +72,9 @@ export default async function HeroSection() {
         </p>
       </div>
 
-      {/* Hero product screenshot — the app IS the hero */}
-      <div className="relative z-10 mt-12 w-full max-w-[1100px]">
-        <div className="relative rounded-xl overflow-hidden border border-[var(--border-light)] shadow-2xl shadow-black/60">
-          <Image
-            src={asset("/docs/ui-overview.webp")}
-            alt="Rive Animation Viewer — full interface with editor, canvas, properties panel, and console"
-            width={1280}
-            height={800}
-            className="w-full h-auto"
-            priority
-          />
-          {/* Bottom fade to blend into next section */}
-          <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-[var(--bg-void)] to-transparent" />
-        </div>
+      {/* Interactive demo — the live app IS the hero */}
+      <div className="relative z-10 mt-12 w-full px-4">
+        <InteractiveDemo />
       </div>
     </section>
   );

--- a/web/src/components/HeroSection.tsx
+++ b/web/src/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import { asset } from "@/lib/config";
 import { getLatestRelease, formatBytes } from "@/lib/github";
-import { Apple, Monitor, Download } from "lucide-react";
+import { Apple, Monitor } from "lucide-react";
 
 export default async function HeroSection() {
   const release = await getLatestRelease();
@@ -10,83 +10,82 @@ export default async function HeroSection() {
   const winDownload = release?.downloads.find(d => d.platform === 'windows');
 
   return (
-    <section className="flex flex-col items-center gap-12 py-24 px-8 hero-gradient w-full">
-      <div className="flex flex-col items-center gap-8 max-w-[800px]">
-        {/* App Icon */}
-        <Image
-          src={asset("/images/app-icon.png")}
-          alt="Rive Animation Viewer"
-          width={120}
-          height={120}
-          className="rounded-[28px] shadow-2xl"
-          priority
-        />
+    <section className="relative flex flex-col items-center pt-32 pb-8 px-8 w-full overflow-hidden">
+      {/* Atmospheric glow */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[600px] rounded-full bg-[#C4F82A] opacity-[0.04] blur-[120px] pointer-events-none" />
+      <div className="absolute top-40 left-1/2 -translate-x-1/2 w-[400px] h-[400px] rounded-full bg-[#C4F82A] opacity-[0.06] blur-[80px] pointer-events-none" />
 
+      <div className="relative z-10 flex flex-col items-center gap-6 max-w-[900px]">
         {/* Version badge */}
         {release && (
-          <div className="flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-[var(--neon-dim)] border border-[var(--neon-glow)]">
-            <div className="w-2 h-2 rounded-full bg-[var(--neon)]" />
-            <span className="text-xs font-mono font-medium text-[var(--neon)]">
-              v{release.version} available
+          <div className="flex items-center gap-2 px-3 py-1 rounded-full border border-[var(--border-light)] bg-[var(--bg-zinc)]">
+            <div className="w-1.5 h-1.5 rounded-full bg-[var(--neon)]" />
+            <span className="text-[11px] font-mono text-[var(--text-muted)]">
+              v{release.version}
             </span>
           </div>
         )}
 
-        {/* Title */}
-        <h1 className="font-sans font-bold text-5xl md:text-[56px] text-center text-[var(--text-white)] leading-tight tracking-tight">
-          The missing desktop companion for Rive
+        {/* Staccato headline */}
+        <h1 className="font-sans font-bold text-[clamp(2.5rem,5vw,4.5rem)] text-center text-[var(--text-white)] leading-[1.1] tracking-tight">
+          Open. Inspect. Ship.
         </h1>
 
-        {/* Tagline */}
-        <p className="text-lg text-center text-[var(--text-dim)] leading-relaxed max-w-[600px]">
-          Open any <code className="text-[var(--neon)] bg-[var(--neon-dim)] px-1.5 py-0.5 rounded text-[15px]">.riv</code> file,
-          bind its ViewModel, activate state machines, and control every property live &mdash; then
-          export the exact snippet your codebase needs.
+        {/* Subtitle — what it actually does */}
+        <p className="text-[clamp(1rem,1.8vw,1.25rem)] text-center text-[var(--text-muted)] leading-relaxed max-w-[600px]">
+          The standalone desktop tool for Rive animations. Load
+          any <code className="text-[var(--neon)] bg-[var(--neon-dim)] px-1.5 py-0.5 rounded text-[0.9em]">.riv</code>,
+          bind ViewModels, drive state machines, and export production-ready code.
         </p>
 
-        {/* Three Platform Download Links */}
-        <div className="flex flex-col sm:flex-row items-center gap-4">
-          {/* Apple Silicon */}
+        {/* Download row */}
+        <div className="flex flex-col sm:flex-row items-center gap-3 mt-2">
           <a
             href={macSilicon?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
-            className="group flex items-center gap-2.5 px-6 py-3 rounded-xl btn-neon text-[14px] hover:scale-105 transition-all duration-300"
+            className="group flex items-center gap-2.5 px-5 py-2.5 rounded-lg btn-neon text-sm font-semibold hover:shadow-[0_0_32px_var(--neon-glow)] transition-shadow duration-300"
           >
-            <Apple className="w-5 h-5 group-hover:scale-110 transition-transform duration-300" />
-            <div className="flex flex-col items-start">
-              <span className="font-semibold">macOS &middot; Apple Silicon</span>
-              {macSilicon && <span className="text-[11px] opacity-60">.dmg &middot; {formatBytes(macSilicon.size)}</span>}
-            </div>
+            <Apple className="w-4 h-4" />
+            <span>Download for Mac</span>
+            {macSilicon && <span className="text-[10px] opacity-50">{formatBytes(macSilicon.size)}</span>}
           </a>
 
-          {/* Intel */}
-          <a
-            href={macIntel?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
-            className="group flex items-center gap-2.5 px-6 py-3 rounded-xl bg-[var(--bg-zinc)] border border-[var(--border-light)] text-[14px] font-semibold text-[var(--text-white)] hover:border-[var(--neon)] hover:scale-105 transition-all duration-300"
-          >
-            <Apple className="w-5 h-5 text-[var(--text-dim)] group-hover:text-[var(--neon)] transition-colors duration-300" />
-            <div className="flex flex-col items-start">
-              <span>macOS &middot; Intel</span>
-              {macIntel && <span className="text-[11px] text-[var(--text-muted)]">.dmg &middot; {formatBytes(macIntel.size)}</span>}
-            </div>
-          </a>
-
-          {/* Windows */}
-          <a
-            href={winDownload?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
-            className="group flex items-center gap-2.5 px-6 py-3 rounded-xl bg-[var(--bg-zinc)] border border-[var(--border-light)] text-[14px] font-semibold text-[var(--text-white)] hover:border-[var(--neon)] hover:scale-105 transition-all duration-300"
-          >
-            <Monitor className="w-5 h-5 text-[var(--text-dim)] group-hover:text-[var(--neon)] transition-colors duration-300" />
-            <div className="flex flex-col items-start">
+          <div className="flex items-center gap-2">
+            <a
+              href={macIntel?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-light)] text-sm text-[var(--text-dim)] hover:text-[var(--text-white)] hover:border-[var(--neon-glow)] transition-colors duration-300"
+            >
+              <Apple className="w-3.5 h-3.5" />
+              <span>Intel</span>
+            </a>
+            <a
+              href={winDownload?.url || "https://github.com/ivg-design/rive-animation-viewer/releases/latest"}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-light)] text-sm text-[var(--text-dim)] hover:text-[var(--text-white)] hover:border-[var(--neon-glow)] transition-colors duration-300"
+            >
+              <Monitor className="w-3.5 h-3.5" />
               <span>Windows</span>
-              {winDownload && <span className="text-[11px] text-[var(--text-muted)]">.msi &middot; {formatBytes(winDownload.size)}</span>}
-            </div>
-          </a>
+            </a>
+          </div>
         </div>
 
-        {/* Requirements */}
-        <p className="text-[13px] text-[var(--text-ghost)]">
-          macOS 11+ (Apple Silicon or Intel) &middot; Windows 10+
+        <p className="text-[11px] text-[var(--text-ghost)] font-mono">
+          macOS 11+ &middot; Windows 10+ &middot; Free &amp; open source
         </p>
+      </div>
+
+      {/* Hero product screenshot — the app IS the hero */}
+      <div className="relative z-10 mt-12 w-full max-w-[1100px]">
+        <div className="relative rounded-xl overflow-hidden border border-[var(--border-light)] shadow-2xl shadow-black/60">
+          <Image
+            src={asset("/docs/ui-overview.webp")}
+            alt="Rive Animation Viewer — full interface with editor, canvas, properties panel, and console"
+            width={1280}
+            height={800}
+            className="w-full h-auto"
+            priority
+          />
+          {/* Bottom fade to blend into next section */}
+          <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-[var(--bg-void)] to-transparent" />
+        </div>
       </div>
     </section>
   );

--- a/web/src/components/HeroSection.tsx
+++ b/web/src/components/HeroSection.tsx
@@ -18,7 +18,7 @@ export default async function HeroSection() {
           alt="Rive Animation Viewer"
           width={120}
           height={120}
-          className="rounded-[28px] shadow-2xl animate-pulse-glow"
+          className="rounded-[28px] shadow-2xl"
           priority
         />
 
@@ -34,13 +34,14 @@ export default async function HeroSection() {
 
         {/* Title */}
         <h1 className="font-sans font-bold text-5xl md:text-[56px] text-center text-[var(--text-white)] leading-tight tracking-tight">
-          Rive Animation Viewer
+          The missing desktop companion for Rive
         </h1>
 
         {/* Tagline */}
         <p className="text-lg text-center text-[var(--text-dim)] leading-relaxed max-w-[600px]">
-          Inspect, debug, and test Rive animations on desktop. ViewModel controls,
-          event console, transparency overlay, and standalone export.
+          Open any <code className="text-[var(--neon)] bg-[var(--neon-dim)] px-1.5 py-0.5 rounded text-[15px]">.riv</code> file,
+          bind its ViewModel, activate state machines, and control every property live &mdash; then
+          export the exact snippet your codebase needs.
         </p>
 
         {/* Three Platform Download Links */}

--- a/web/src/components/InteractiveDemo.tsx
+++ b/web/src/components/InteractiveDemo.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+
+const hotspots = [
+  {
+    id: "toolbar",
+    label: "Toolbar",
+    description: "Playback controls, renderer, fit mode, alignment, and FPS — all in one row.",
+    // Positioned over the toolbar area (percentages of iframe)
+    top: "5.5%", left: "25%", width: "50%", height: "5%",
+  },
+  {
+    id: "editor",
+    label: "Script Editor",
+    description: "Write JavaScript config objects to control artboard, state machines, callbacks, and canvas sizing. Apply to re-instantiate the runtime.",
+    top: "12%", left: "0%", width: "24%", height: "68%",
+  },
+  {
+    id: "canvas",
+    label: "Canvas",
+    description: "The animation viewport. Drop a .riv file here or use the OPEN button. Supports WebGL2 and Canvas renderers.",
+    top: "12%", left: "24%", width: "52%", height: "60%",
+  },
+  {
+    id: "properties",
+    label: "Properties",
+    description: "Auto-discovered ViewModel controls and state machine inputs. Switch artboards, select VM instances, and reset to defaults.",
+    top: "12%", left: "76%", width: "24%", height: "68%",
+  },
+  {
+    id: "console",
+    label: "Console",
+    description: "Event log or JavaScript REPL. Filter by source, search, follow latest entries, and copy the visible transcript.",
+    top: "73%", left: "0%", width: "76%", height: "20%",
+  },
+  {
+    id: "runtime-strip",
+    label: "Runtime Strip",
+    description: "MCP status, console toggle, runtime version, loaded file, and auto-update indicator.",
+    top: "93%", left: "0%", width: "100%", height: "4%",
+  },
+  {
+    id: "open-btn",
+    label: "Open",
+    description: "Load any .riv file from disk. Also supports drag-and-drop onto the canvas.",
+    top: "5.5%", left: "5%", width: "8%", height: "5%",
+  },
+  {
+    id: "export-btn",
+    label: "Export",
+    description: "Generate standalone HTML demos and copy-paste instantiation snippets with per-control selection.",
+    top: "5.5%", left: "80%", width: "9%", height: "5%",
+  },
+];
+
+export default function InteractiveDemo() {
+  const [activeHotspot, setActiveHotspot] = useState<string | null>(null);
+  const active = hotspots.find(h => h.id === activeHotspot);
+
+  return (
+    <div className="relative w-full max-w-[1100px] mx-auto">
+      {/* Iframe container */}
+      <div className="relative rounded-xl overflow-hidden border border-[var(--border-light)] shadow-2xl shadow-black/60 aspect-[1280/800]">
+        <iframe
+          src="http://localhost:1420"
+          className="absolute inset-0 w-full h-full border-0"
+          title="RAV Interactive Demo"
+          loading="lazy"
+          sandbox="allow-scripts allow-same-origin"
+        />
+
+        {/* Hotspot overlay */}
+        <div className="absolute inset-0 z-10">
+          {hotspots.map((spot) => (
+            <div
+              key={spot.id}
+              className={`absolute cursor-pointer transition-all duration-200 rounded-md ${
+                activeHotspot === spot.id
+                  ? "bg-[var(--neon)]/10 ring-1 ring-[var(--neon)]/40"
+                  : "hover:bg-[var(--neon)]/5"
+              }`}
+              style={{
+                top: spot.top,
+                left: spot.left,
+                width: spot.width,
+                height: spot.height,
+              }}
+              onMouseEnter={() => setActiveHotspot(spot.id)}
+              onMouseLeave={() => setActiveHotspot(null)}
+            />
+          ))}
+        </div>
+
+        {/* Callout */}
+        {active && (
+          <div
+            className="absolute z-20 pointer-events-none animate-[fadeIn_150ms_ease-out]"
+            style={{
+              top: `calc(${active.top} + ${active.height})`,
+              left: active.left,
+              maxWidth: "320px",
+            }}
+          >
+            <div className="mt-2 p-3 rounded-lg bg-[var(--bg-zinc)]/95 backdrop-blur-sm border border-[var(--neon)]/30 shadow-xl shadow-black/50">
+              <p className="text-xs font-semibold text-[var(--neon)] mb-1 font-mono tracking-wider uppercase">
+                {active.label}
+              </p>
+              <p className="text-[13px] text-[var(--text-dim)] leading-relaxed">
+                {active.description}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Bottom fade */}
+        <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-[var(--bg-void)] to-transparent z-[5] pointer-events-none" />
+      </div>
+
+      {/* Hint text */}
+      <p className="text-center text-[11px] text-[var(--text-ghost)] mt-3 font-mono">
+        Hover over any region to explore the interface
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/ScrollReveal.tsx
+++ b/web/src/components/ScrollReveal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+const variants = {
+  hidden: { opacity: 0, y: 32 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export default function ScrollReveal({
+  children,
+  className,
+  delay = 0,
+}: {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}) {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-80px" }}
+      transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1], delay }}
+      variants={variants}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function ScrollRevealGroup({
+  children,
+  className,
+  stagger = 0.08,
+}: {
+  children: ReactNode;
+  className?: string;
+  stagger?: number;
+}) {
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: "-60px" }}
+      transition={{ staggerChildren: stagger }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function ScrollRevealItem({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <motion.div
+      variants={variants}
+      transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

Bumps the bundled MCP sidecar from **32 → 36 tools** and ships an internal script-console refactor that the new tools build on top of.

### New MCP tools

| Tool | Purpose |
|---|---|
| `rav_console_set_mode` | Flip events / js / closed without re-opening the panel |
| `rav_console_set_filter` | Drive the on-screen filter toggles: `level` for JS, `sources` for Events, plus `search` on either; auto-targets active mode |
| `rav_console_clear` | Clear the visible transcript of the active (or specified) mode; panel stays open |
| `rav_export_demo_visual` | Visibly orchestrate the Snippet & Export Controls dialog (selection → package → mode → Export → save) for screen recordings or non-default selections |

### Extended

- `rav_console_open` now accepts optional `mode` / `level` / `sources` / `search` to apply pre-configured filter state in the same call. Backwards compatible.

### Console refactor (no user-visible behavior change)

- Eruda configuration extracted into `console/eruda/configure-tool.js`
- `summarizeConsoleExecution` extracted into `console/exec-outcome.js`
- `capture-controller` owns Eruda logger attachment + type mapping (`input → command`, `output → result`, `verbose → debug`)
- `presentation` and `ui-state-controller` slimmed down accordingly
- Test suite rewritten to match the new shape

### Surface mirrored everywhere

- `mcp-server/tools/editor-tools.js` + `instructions.js` (Node)
- `src-tauri/src/bin/rav-mcp/tool_registry.rs` + `support/instructions.rs` (Rust)
- `web/src/app/docs/mcp/page.tsx` + `web/src/app/docs/page.tsx` + `web/src/components/FeaturesSection.tsx` (32 → 36, new tool rows)
- `CHANGELOG.md` + `web/CHANGELOG.md`

## Test plan

- [x] `npm test` — 181/181 passing (architecture + dep-cruise + vitest)
- [x] `cargo build --release --bin rav-mcp` — clean
- [x] Live MCP smoke against running RAV (Scratchcard.riv): all 4 new tools + extended `rav_console_open` exercised end-to-end. `rav_export_demo_visual` produced 9.22 MB / 9.16 MB / 9.16 MB for `selection: all` / `none` / `["fake-key"]` — sizes confirm the dialog selection genuinely drives output and the new `data-control-key` attribute is on the rendered checkboxes
- [ ] Auto-updater pickup verified after release tag publishes `latest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)