### PR TITLE
fix(mcp): resolve bundled sidecar beside app

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -296,6 +296,9 @@ the direct Vercel deployment and the public Forge URL.
 5. Download a DMG through a browser, install it on a clean Mac, disconnect
    networking, and confirm Gatekeeper launches it normally using the stapled
    ticket.
-6. Install 2.4.0, update to 2.4.1 in-app, relaunch, confirm About reports 2.4.1,
-   and confirm the next updater check reports no newer version.
+6. For the planned 2.4.2 hotfix, install 2.4.1, update to 2.4.2 in-app, and
+   relaunch. Confirm About reports 2.4.2, the next updater check reports no
+   newer version, `Contents/MacOS/rav-mcp` exists in the installed app, the MCP
+   chip reaches its healthy state, and the stable client launcher resolves to
+   that bundled sidecar.
 7. Deploy the website and verify its downloads and changelog.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,10 @@ application executable. On macOS that is
 `Rive Animation Viewer.app/Contents/MacOS/rav-mcp`; it is signed before the
 outer app with the same Developer ID identity, secure timestamp, and hardened
 runtime. Do not copy executable code through Tauri's generic Resources bundle.
+Runtime discovery must derive the sidecar path from
+`std::env::current_exe()` and join `rav-mcp` to that executable's parent
+directory. Do not use a generic application resource or base-directory
+resolver for this sibling-binary contract.
 Development builds create the debug sidecar explicitly before `tauri dev`.
 
 ## Decision Rules For New Work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Packaged MCP sidecar discovery** — RAV now resolves `rav-mcp` from the running application's executable directory instead of Tauri's generic executable-directory resolver. This restores automatic MCP bridge startup for packaged macOS apps affected by the 2.4.1 regression and refreshes an existing stable client launcher after an app update.
+
 ## [2.4.1] - 2026-07-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ These gates materially reduce regression risk, but they are still code- and DOM-
 - **Single signed MCP binary**: RAV now packages one `rav-mcp` beside the main executable, where Tauri signs it inside-out with the app. The redundant unsigned Resources copy is gone.
 - **Atomic, bounded releases**: Complete platform inventory, signing checks, job timeouts, concurrency protection, and a final draft gate prevent partial or runaway releases from becoming public.
 
+### Known MCP issue in 2.4.1
+
+RAV 2.4.1 includes the signed sidecar at
+`Rive Animation Viewer.app/Contents/MacOS/rav-mcp`, but its packaged macOS
+startup path can report that the sidecar is missing. The bundle has not moved:
+the failure is in resolving the directory that contains the running app
+executable. The fix resolves `rav-mcp` as that executable's sibling and is
+planned for the 2.4.2 patch.
+
+Until 2.4.2 is available, keep this command running in Terminal to start the
+installed sidecar manually:
+
+```bash
+"/Applications/Rive Animation Viewer.app/Contents/MacOS/rav-mcp" --bridge-only --port 9274
+```
+
+If MCP Setup uses a custom port, replace `9274` with that port. Install 2.4.2
+through the updater when it is offered; reinstalling 2.4.1 does not repair the
+path-resolution failure.
+
 ## 2.4.0 Highlights
 
 - **Dynamic ViewModel lists**: List instances populate as soon as a file opens and rebuild when their controlling count changes, with readable `Row 1`, `Row 2`, … labels instead of an arbitrary ten-item ceiling.
@@ -220,7 +240,7 @@ The key rule is simple: new hand-written source files may not exceed `400` lines
 MCP Client ←(stdio)→ rav-mcp sidecar ←(WebSocket :9274)→ RAV Frontend
 ```
 
-The desktop app bundles one native `rav-mcp` sidecar beside the main application executable and exposes a stable launcher path for external clients. On macOS, Tauri applies the same Developer ID, hardened-runtime, and timestamp requirements to the sidecar before signing the outer app. The frontend MCP bridge client starts automatically when RAV launches, attaches to the configured port, and keeps retrying until a client attaches.
+The desktop app bundles one native `rav-mcp` sidecar beside the main application executable and exposes a stable launcher path for external clients. On macOS, the exact location is `Rive Animation Viewer.app/Contents/MacOS/rav-mcp`; RAV derives it from the running executable's parent directory. Tauri applies the same Developer ID, hardened-runtime, and timestamp requirements to the sidecar before signing the outer app. The frontend MCP bridge client starts automatically when RAV launches, attaches to the configured port, and keeps retrying until a client attaches.
 
 #### Setup (one-time)
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -145,6 +145,18 @@ Check the browser console for `[rav-mcp-bridge]` messages.
 port from the MCP Setup dialog. The bridge starts automatically with the app
 and keeps retrying until a client attaches.
 
+**RAV 2.4.1 says the sidecar is not beside the app executable (macOS)** - The
+signed sidecar is present at
+`/Applications/Rive Animation Viewer.app/Contents/MacOS/rav-mcp`; 2.4.1 can
+fail while resolving its sibling path. Update to the planned 2.4.2 patch when
+it is offered. Reinstalling 2.4.1 does not fix this regression. As a temporary
+workaround, keep the following command running and substitute the MCP Setup
+port if it is not `9274`:
+
+```bash
+"/Applications/Rive Animation Viewer.app/Contents/MacOS/rav-mcp" --bridge-only --port 9274
+```
+
 **Desktop app setup still mentions Node** - Update to a build that includes the
 native `rav-mcp` sidecar and use the in-app MCP Setup dialog instead of the
 source-only JS server path.

--- a/src-tauri/src/app/mcp/bridge.rs
+++ b/src-tauri/src/app/mcp/bridge.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::net::{SocketAddr, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::Duration;
 
@@ -19,28 +19,40 @@ use crate::app::support::ensure_parent_directory;
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-pub fn resolve_mcp_server_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+fn resolve_mcp_server_path_from_executable(
+    executable_path: &Path,
+    binary_name: &str,
+) -> Result<PathBuf, String> {
+    executable_path
+        .parent()
+        .map(|directory| directory.join(binary_name))
+        .ok_or_else(|| {
+            format!(
+                "Application executable has no parent directory: {}",
+                executable_path.display()
+            )
+        })
+}
+
+pub fn resolve_mcp_server_path(_app: &tauri::AppHandle) -> Result<PathBuf, String> {
     let binary_name = if cfg!(target_os = "windows") {
         "rav-mcp.exe"
     } else {
         "rav-mcp"
     };
 
-    let executable_dir = app
-        .path()
-        .executable_dir()
-        .map_err(|error| format!("Failed to resolve app executable directory: {error}"))?;
-    let sidecar_path = executable_dir.join(binary_name);
+    let executable_path = std::env::current_exe()
+        .map_err(|error| format!("Failed to resolve current application executable: {error}"))?;
+    let sidecar_path = resolve_mcp_server_path_from_executable(&executable_path, binary_name)?;
 
-    sidecar_path
-        .exists()
-        .then_some(sidecar_path)
-        .ok_or_else(|| {
-            format!(
-                "MCP server not found beside the application executable: {}",
-                binary_name
-            )
-        })
+    if sidecar_path.is_file() {
+        Ok(sidecar_path)
+    } else {
+        Err(format!(
+            "MCP server not found beside the application executable: {}",
+            sidecar_path.display()
+        ))
+    }
 }
 
 pub fn mcp_client_launcher_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
@@ -111,6 +123,21 @@ pub fn ensure_mcp_client_launcher(app: &tauri::AppHandle) -> Result<PathBuf, Str
     }
 
     Ok(launcher_path)
+}
+
+pub fn refresh_mcp_client_launcher_if_present(
+    app: &tauri::AppHandle,
+) -> Result<Option<PathBuf>, String> {
+    let launcher_path = mcp_client_launcher_path(app)?;
+    match fs::symlink_metadata(&launcher_path) {
+        Ok(_) => ensure_mcp_client_launcher(app).map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!(
+            "Failed to inspect MCP launcher at {}: {}",
+            launcher_path.display(),
+            error
+        )),
+    }
 }
 
 pub fn mcp_server_path_candidates(app: &tauri::AppHandle) -> Result<Vec<PathBuf>, String> {
@@ -342,6 +369,10 @@ pub fn get_mcp_port(
     let port = ensure_mcp_bridge_running(&app, &bridge_manager)?;
     Ok(port)
 }
+
+#[cfg(test)]
+#[path = "bridge_tests.rs"]
+mod tests;
 
 #[tauri::command]
 pub fn set_mcp_port(

--- a/src-tauri/src/app/mcp/bridge_tests.rs
+++ b/src-tauri/src/app/mcp/bridge_tests.rs
@@ -1,0 +1,22 @@
+use super::resolve_mcp_server_path_from_executable;
+use std::path::PathBuf;
+
+#[test]
+fn resolves_sidecar_beside_the_running_executable() {
+    let executable_path = PathBuf::from("bundle").join("bin").join("app");
+    let sidecar_path =
+        resolve_mcp_server_path_from_executable(&executable_path, "rav-mcp").unwrap();
+
+    assert_eq!(
+        sidecar_path,
+        PathBuf::from("bundle").join("bin").join("rav-mcp")
+    );
+}
+
+#[test]
+fn rejects_an_executable_without_a_parent_directory() {
+    let executable_path = PathBuf::from(std::path::MAIN_SEPARATOR.to_string());
+    let error = resolve_mcp_server_path_from_executable(&executable_path, "rav-mcp").unwrap_err();
+
+    assert!(error.contains("has no parent directory"));
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,9 @@ use tauri::menu::{PredefinedMenuItem, Submenu, WINDOW_SUBMENU_ID};
 use tauri::{Emitter, Manager};
 
 use crate::app::constants::{ABOUT_MENU_ID, DEFAULT_MCP_PORT, ONLINE_DOCS_MENU_ID, RAV_DOCS_URL};
-use crate::app::mcp::bridge::{initialize_mcp_bridge, kill_spawned_mcp_bridge};
+use crate::app::mcp::bridge::{
+    initialize_mcp_bridge, kill_spawned_mcp_bridge, refresh_mcp_client_launcher_if_present,
+};
 use crate::app::state::{McpBridgeManager, OpenedFiles, PendingAppUpdate};
 use crate::app::support::{
     extract_opened_riv_file_args, extract_opened_riv_file_args_from_iter, looks_like_riv_file,
@@ -75,6 +77,9 @@ fn main() {
             let bridge_manager = app.state::<McpBridgeManager>();
             if let Err(error) = initialize_mcp_bridge(app.handle(), &bridge_manager) {
                 eprintln!("[rav-app] failed to start MCP bridge: {error}");
+            }
+            if let Err(error) = refresh_mcp_client_launcher_if_present(app.handle()) {
+                eprintln!("[rav-app] failed to refresh MCP client launcher: {error}");
             }
             Ok(())
         })

--- a/tests/smoke/ui-regressions.smoke.test.js
+++ b/tests/smoke/ui-regressions.smoke.test.js
@@ -108,7 +108,6 @@ describe('ui regression smoke', () => {
         const tauriWindowsConfig = JSON.parse(readFileSync(path.join(repoRoot, 'src-tauri', 'tauri.windows.conf.json'), 'utf8'));
         const cargoToml = readFileSync(path.join(repoRoot, 'src-tauri', 'Cargo.toml'), 'utf8');
         const mainRs = readFileSync(path.join(repoRoot, 'src-tauri', 'src', 'main.rs'), 'utf8');
-        const mcpBridge = readFileSync(path.join(repoRoot, 'src-tauri', 'src', 'app', 'mcp', 'bridge.rs'), 'utf8');
         const windowControls = readFileSync(path.join(repoRoot, 'src-tauri', 'src', 'app', 'window', 'controls.rs'), 'utf8');
         const capability = JSON.parse(readFileSync(path.join(repoRoot, 'src-tauri', 'capabilities', 'default.json'), 'utf8'));
         const mainWindow = tauriConfig.app.windows[0];
@@ -120,8 +119,6 @@ describe('ui regression smoke', () => {
         expect(tauriConfig.bundle.macOS.signingIdentity).toBeUndefined();
         expect(tauriConfig.bundle.resources).toBeUndefined();
         expect(tauriConfig.build.beforeDevCommand).toContain('build:mcp:debug');
-        expect(mcpBridge).toContain('executable_dir()');
-        expect(mcpBridge).not.toContain('resource_dir()');
         expect(mainWindow.decorations).toBe(true);
         expect(mainWindow.transparent).toBe(true);
         expect(mainWindow.titleBarStyle).toBe('Overlay');
@@ -146,6 +143,15 @@ describe('ui regression smoke', () => {
             'core:window:allow-start-dragging',
             'core:window:allow-toggle-maximize',
         ]));
+    });
+
+    it('resolves the bundled MCP sidecar beside the running executable', () => {
+        const mcpBridge = readFileSync(path.join(repoRoot, 'src-tauri', 'src', 'app', 'mcp', 'bridge.rs'), 'utf8');
+
+        expect(mcpBridge).toContain('std::env::current_exe()');
+        expect(mcpBridge).toContain('resolve_mcp_server_path_from_executable');
+        expect(mcpBridge).not.toContain('.executable_dir()');
+        expect(mcpBridge).not.toContain('resource_dir()');
     });
 
     it('keeps the exported demo on the current fullscreen and event-log chrome contract', () => {

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Packaged MCP sidecar discovery** — RAV now resolves `rav-mcp` from the running application's executable directory, restoring automatic MCP bridge startup for macOS installations affected by the 2.4.1 regression and refreshing an existing stable client launcher after an update.
+
 ## [2.4.1] - 2026-07-25
 
 ### Changed


### PR DESCRIPTION
## What changed

- resolve `rav-mcp` from the running executable's parent directory instead of Tauri's unsupported generic executable-directory API
- refresh an existing stable MCP launcher during app startup so updater replacements repair stale symlinks
- replace the incorrect smoke assertion with focused Rust and smoke regression coverage
- document the v2.4.1 regression, temporary workaround, 2.4.2 verification, and sibling-binary architecture contract

## Why

RAV 2.4.1 packages a correctly signed and notarized `Contents/MacOS/rav-mcp`, but `PathResolver::executable_dir()` is unsupported on macOS and Windows and does not mean the current binary's directory on Linux. The resolver therefore failed before it could inspect or spawn the bundled sidecar.

## Impact

Packaged builds can start the MCP bridge again, MCP Setup can resolve the bundled server, and existing stable launcher symlinks are refreshed after an app update. The bundle layout and signing/notarization remain unchanged.

## Validation

- `npm test` — 43 files, 226 tests passed
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml` — 8 tests passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `git diff --check`