### PR TITLE
Make RAV 2.4.3 acceptance tests Windows-portable

### DIFF
--- a/tests/unit/platform/demo-template-vm.test.js
+++ b/tests/unit/platform/demo-template-vm.test.js
@@ -2,13 +2,15 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const templateRoot = path.resolve(process.cwd(), 'src-tauri/src/demo-template/js');
-const accessorsSource = readFileSync(path.join(templateRoot, 'vm/accessors.js'), 'utf8');
-const hierarchySource = readFileSync(path.join(templateRoot, 'vm/hierarchy.js'), 'utf8');
-const preambleSource = readFileSync(path.join(templateRoot, 'core/preamble.js'), 'utf8');
-const riveLoaderSource = readFileSync(path.join(templateRoot, 'core/rive-loader.js'), 'utf8');
-const editorConfigSource = readFileSync(path.join(templateRoot, 'core/editor-config.js'), 'utf8');
-const controlsRenderSource = readFileSync(path.join(templateRoot, 'vm/controls-render.js'), 'utf8');
-const syncSource = readFileSync(path.join(templateRoot, 'vm/sync.js'), 'utf8');
+const readTemplateSource = (relativePath) => readFileSync(path.join(templateRoot, relativePath), 'utf8')
+    .replace(/\r\n?/g, '\n');
+const accessorsSource = readTemplateSource('vm/accessors.js');
+const hierarchySource = readTemplateSource('vm/hierarchy.js');
+const preambleSource = readTemplateSource('core/preamble.js');
+const riveLoaderSource = readTemplateSource('core/rive-loader.js');
+const editorConfigSource = readTemplateSource('core/editor-config.js');
+const controlsRenderSource = readTemplateSource('vm/controls-render.js');
+const syncSource = readTemplateSource('vm/sync.js');
 
 function createDemoVmHarness(riveInstance, { controlSelectionKeys = null, controlSnapshot = [], vmHierarchy = null } = {}) {
     const build = new Function('riveInstance', 'CONTROL_SELECTION_KEYS', 'CONTROL_SNAPSHOT', 'VM_HIERARCHY', `

--- a/tests/unit/scripts/updater-acceptance.test.js
+++ b/tests/unit/scripts/updater-acceptance.test.js
@@ -115,12 +115,16 @@ describe('updater acceptance provenance', () => {
     });
 
     it('limits destructive cleanup to executables inside the isolated app bundle', () => {
-        const appPath = '/private/tmp/rav-acceptance/Rive Animation Viewer.app';
+        const appPath = path.join(os.tmpdir(), 'rav-acceptance', 'Rive Animation Viewer.app');
+        const acceptanceExecutable = path.join(appPath, 'Contents', 'MacOS', 'rive-animation-viewer');
         expect(processCommandBelongsToApp(
-            `${appPath}/Contents/MacOS/rive-animation-viewer --acceptance`,
+            `${acceptanceExecutable} --acceptance`,
             appPath,
         )).toBe(true);
-        expect(processCommandBelongsToApp('/Applications/Other.app/Contents/MacOS/other', appPath)).toBe(false);
+        expect(processCommandBelongsToApp(
+            path.join(os.tmpdir(), 'Other.app', 'Contents', 'MacOS', 'other'),
+            appPath,
+        )).toBe(false);
     });
 
     it('creates and re-verifies a byte-exact signed private-draft ledger', async () => {


### PR DESCRIPTION
## What changed

- builds updater-acceptance test paths with native path utilities
- normalizes checked-in demo-template source line endings before source-string assertions

## Why

The private Windows x64 build stopped in its pre-build test gate on Windows-specific path separators and CRLF checkout line endings. Production code was correct; the tests were platform-specific.

## Validation

- focused Vitest: 2 files / 24 tests passed
- architecture and dependency checks passed
- git diff check passed

No public release or website deployment is included.