### PR TITLE
chore(release): v2.4.3

### DIFF
--- a/scripts/generate-snippet-modules.mjs
+++ b/scripts/generate-snippet-modules.mjs
@@ -80,7 +80,17 @@ function extractBraceBlock(source, marker) {
 
 async function writeModule(filePath, content) {
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, `${content.trimEnd()}\n`, 'utf8');
+    let lineEnding = '\n';
+    try {
+        if ((await fs.readFile(filePath, 'utf8')).includes('\r\n')) lineEnding = '\r\n';
+    } catch (error) {
+        if (error.code !== 'ENOENT') throw error;
+    }
+    const normalized = content
+        .trimEnd()
+        .replace(/\r\n?/g, '\n')
+        .replace(/\n/g, lineEnding);
+    await fs.writeFile(filePath, `${normalized}${lineEnding}`, 'utf8');
 }
 
 async function main() {


### PR DESCRIPTION
Approved one-file recovery for the Windows-only false `-dirty` packaged UI identity.\n\nCandidate tree: `0ab8752deec70a7417f270b83e0abe875f54d90b`\nCandidate digest: `1480432c187a0d50222e8af8e6020a838350cded4ba5cce26897f0de9718c4c3`\nPatch SHA-256: `48b74c927323c1f0616bd1c3c45dd0dd247a9630484c4754a3ce14f615c0f4c3`\n\nFocused validation: build-stamp unit 1/1; LF generation clean; isolated `core.autocrlf=true` generation and build identity clean. No packaging implementation changed.