### PR TITLE
chore(release): v2.4.3

### DIFF
--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -8,6 +8,10 @@ const distDir = path.join(root, 'dist');
 const buildCounterFile = path.join(root, '.cache', 'build-counter.txt');
 const pkg = JSON.parse(await fs.readFile(path.join(root, 'package.json'), 'utf8'));
 
+function isCiBuild() {
+  return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+}
+
 function getGitShortSha() {
   try {
     return execSync('git rev-parse --short HEAD', {
@@ -20,15 +24,19 @@ function getGitShortSha() {
   }
 }
 
-function getGitWorktreeSuffix() {
+function getGitWorktreeStatus() {
   try {
-    const status = execSync('git status --porcelain --untracked-files=all', {
+    return execSync('git status --porcelain=v2 --untracked-files=all', {
       cwd: root,
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf8',
     }).trim();
-    return status ? '-dirty' : '';
-  } catch {
+  } catch (error) {
+    if (isCiBuild()) {
+      console.error('Unable to collect Git worktree status for a CI distribution build.');
+      throw new Error('CI distribution builds require readable Git status.', { cause: error });
+    }
+    console.warn('Unable to collect Git worktree status; local build cleanliness is unknown.');
     return '';
   }
 }
@@ -115,7 +123,13 @@ async function copyDir(src, dest) {
 }
 
 async function build() {
-  const gitWorktreeSuffix = getGitWorktreeSuffix();
+  const gitWorktreeStatus = getGitWorktreeStatus();
+  if (gitWorktreeStatus && isCiBuild()) {
+    console.error('Refusing CI distribution build from a dirty Git checkout:');
+    console.error(gitWorktreeStatus);
+    throw new Error('CI distribution builds require a clean Git checkout.');
+  }
+  const gitWorktreeSuffix = gitWorktreeStatus ? '-dirty' : '';
   await fs.rm(distDir, { recursive: true, force: true });
   await ensureDir(distDir);
   const cliBuildNumber = parseCliBuildNumber(process.argv.slice(2));

--- a/tests/unit/scripts/build-dist.test.js
+++ b/tests/unit/scripts/build-dist.test.js
@@ -1,12 +1,12 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 
 const root = path.resolve(process.cwd());
 
-function run(cwd, command, args) {
-    return execFileSync(command, args, { cwd, encoding: 'utf8' });
+function run(cwd, command, args, env = process.env) {
+    return execFileSync(command, args, { cwd, encoding: 'utf8', env });
 }
 
 function buildIdFrom(output) {
@@ -14,7 +14,7 @@ function buildIdFrom(output) {
 }
 
 describe('static distribution build identity', () => {
-    it('ignores its own counter write but still marks a genuinely dirty checkout', () => {
+    it('marks local dirtiness and blocks dirty CI builds with exact status', () => {
         const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'rav-build-dist-'));
 
         try {
@@ -39,8 +39,33 @@ describe('static distribution build identity', () => {
             expect(fs.existsSync(path.join(fixture, '.cache', 'build-counter.txt'))).toBe(true);
 
             fs.writeFileSync(path.join(fixture, 'genuinely-dirty.txt'), 'dirty\n');
-            const dirtyId = buildIdFrom(run(fixture, process.execPath, ['scripts/build-dist.mjs']));
+            const localEnv = { ...process.env, CI: '', GITHUB_ACTIONS: '' };
+            const dirtyId = buildIdFrom(run(
+                fixture,
+                process.execPath,
+                ['scripts/build-dist.mjs'],
+                localEnv,
+            ));
             expect(dirtyId).toContain('-dirty');
+
+            const blocked = spawnSync(process.execPath, ['scripts/build-dist.mjs'], {
+                cwd: fixture,
+                encoding: 'utf8',
+                env: { ...process.env, CI: 'true' },
+            });
+            expect(blocked.status).not.toBe(0);
+            expect(blocked.stderr).toContain('Refusing CI distribution build from a dirty Git checkout:');
+            expect(blocked.stderr).toContain('genuinely-dirty.txt');
+
+            fs.renameSync(path.join(fixture, '.git'), path.join(fixture, '.git-unavailable'));
+            const statusUnavailable = spawnSync(process.execPath, ['scripts/build-dist.mjs'], {
+                cwd: fixture,
+                encoding: 'utf8',
+                env: { ...process.env, CI: 'true' },
+            });
+            expect(statusUnavailable.status).not.toBe(0);
+            expect(statusUnavailable.stderr)
+                .toContain('Unable to collect Git worktree status for a CI distribution build.');
         } finally {
             fs.rmSync(fixture, { recursive: true, force: true });
         }


### PR DESCRIPTION
Fail closed before distribution when CI cannot collect Git worktree status, and emit exact porcelain-v2 entries when CI is dirty.\n\nCandidate tree: `33f3addb801596e574d743d6b756a4adf6b7c279`\n\nFocused validation: `npx vitest run tests/unit/scripts/build-dist.test.js` (1/1 passed); `git diff --check` passed.