### PR TITLE
chore(release): v2.4.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src-tauri/Cargo.toml text eol=lf

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 
 const root = process.cwd();
 const distDir = path.join(root, 'dist');
@@ -24,20 +24,63 @@ function getGitShortSha() {
   }
 }
 
-function getGitWorktreeStatus() {
+function runGit(args, allowedStatuses = [0]) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (!allowedStatuses.includes(result.status)) {
+    const stderr = result.stderr.trim();
+    throw new Error(
+      `git ${args.join(' ')} exited with status ${result.status}${stderr ? `: ${stderr}` : ''}`,
+    );
+  }
+  return result;
+}
+
+function getGitWorktreeState() {
   try {
-    return execSync('git status --porcelain=v2 --untracked-files=all', {
-      cwd: root,
-      stdio: ['ignore', 'pipe', 'ignore'],
-      encoding: 'utf8',
-    }).trim();
+    // Use content-aware comparisons for tracked files. On Windows, Tauri's TOML
+    // round-trip can change CRLF worktree bytes to LF while Git's normalized
+    // content remains identical; porcelain status alone can mislabel that as dirty.
+    const unstaged = runGit(['diff', '--quiet', '--no-ext-diff', '--'], [0, 1]);
+    const staged = runGit(['diff', '--cached', '--quiet', '--no-ext-diff', '--'], [0, 1]);
+    const untrackedResult = runGit(['ls-files', '--others', '--exclude-standard', '-z']);
+    const untracked = untrackedResult.stdout.split('\0').filter(Boolean);
+    const dirty = unstaged.status === 1 || staged.status === 1 || untracked.length > 0;
+    const diagnostics = [];
+
+    if (unstaged.status === 1) {
+      const details = runGit(['diff', '--name-status', '--no-ext-diff', '--']).stdout.trim();
+      diagnostics.push(`unstaged:\n${details || '(tracked content differs)'}`);
+    }
+    if (staged.status === 1) {
+      const details = runGit([
+        'diff',
+        '--cached',
+        '--name-status',
+        '--no-ext-diff',
+        '--',
+      ]).stdout.trim();
+      diagnostics.push(`staged:\n${details || '(index content differs)'}`);
+    }
+    if (untracked.length > 0) {
+      diagnostics.push(`untracked:\n${untracked.map((file) => `? ${file}`).join('\n')}`);
+    }
+
+    return { dirty, diagnostics: diagnostics.join('\n') };
   } catch (error) {
     if (isCiBuild()) {
       console.error('Unable to collect Git worktree status for a CI distribution build.');
       throw new Error('CI distribution builds require readable Git status.', { cause: error });
     }
     console.warn('Unable to collect Git worktree status; local build cleanliness is unknown.');
-    return '';
+    return { dirty: false, diagnostics: '' };
   }
 }
 
@@ -123,13 +166,13 @@ async function copyDir(src, dest) {
 }
 
 async function build() {
-  const gitWorktreeStatus = getGitWorktreeStatus();
-  if (gitWorktreeStatus && isCiBuild()) {
+  const gitWorktreeState = getGitWorktreeState();
+  if (gitWorktreeState.dirty && isCiBuild()) {
     console.error('Refusing CI distribution build from a dirty Git checkout:');
-    console.error(gitWorktreeStatus);
+    console.error(gitWorktreeState.diagnostics);
     throw new Error('CI distribution builds require a clean Git checkout.');
   }
-  const gitWorktreeSuffix = gitWorktreeStatus ? '-dirty' : '';
+  const gitWorktreeSuffix = gitWorktreeState.dirty ? '-dirty' : '';
   await fs.rm(distDir, { recursive: true, force: true });
   await ensureDir(distDir);
   const cliBuildNumber = parseCliBuildNumber(process.argv.slice(2));

--- a/tests/unit/scripts/build-dist.test.js
+++ b/tests/unit/scripts/build-dist.test.js
@@ -14,7 +14,19 @@ function buildIdFrom(output) {
 }
 
 describe('static distribution build identity', () => {
-    it('marks local dirtiness and blocks dirty CI builds with exact status', () => {
+    it('pins the Tauri manifest to LF on every checkout', () => {
+        const attributes = run(root, 'git', [
+            'check-attr',
+            'text',
+            'eol',
+            '--',
+            'src-tauri/Cargo.toml',
+        ]);
+        expect(attributes).toContain('src-tauri/Cargo.toml: text: set');
+        expect(attributes).toContain('src-tauri/Cargo.toml: eol: lf');
+    });
+
+    it('ignores normalized EOL-only rewrites and blocks real Git dirtiness', () => {
         const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'rav-build-dist-'));
 
         try {
@@ -27,6 +39,9 @@ describe('static distribution build identity', () => {
             fs.writeFileSync(path.join(fixture, 'package.json'), '{"version":"1.0.0"}\n');
             fs.writeFileSync(path.join(fixture, 'src', 'app', 'main-entry.js'), '__APP_BUILD__\n');
             fs.writeFileSync(path.join(fixture, '.gitignore'), '.cache/\ndist/\n');
+            fs.writeFileSync(path.join(fixture, '.gitattributes'), 'eol-equivalent.txt text\n');
+            fs.writeFileSync(path.join(fixture, 'eol-equivalent.txt'), 'same\n');
+            fs.writeFileSync(path.join(fixture, 'tracked.txt'), 'original\n');
 
             run(fixture, 'git', ['init', '-q']);
             run(fixture, 'git', ['config', 'user.email', 'test@example.invalid']);
@@ -38,6 +53,41 @@ describe('static distribution build identity', () => {
             expect(cleanId).not.toContain('-dirty');
             expect(fs.existsSync(path.join(fixture, '.cache', 'build-counter.txt'))).toBe(true);
 
+            fs.writeFileSync(path.join(fixture, 'eol-equivalent.txt'), 'same\r\n');
+            expect(spawnSync('git', ['diff', '--quiet', '--', 'eol-equivalent.txt'], {
+                cwd: fixture,
+            }).status).toBe(0);
+            const normalizedId = buildIdFrom(run(
+                fixture,
+                process.execPath,
+                ['scripts/build-dist.mjs'],
+            ));
+            expect(normalizedId).not.toContain('-dirty');
+
+            fs.writeFileSync(path.join(fixture, 'tracked.txt'), 'unstaged change\n');
+            const unstaged = spawnSync(process.execPath, ['scripts/build-dist.mjs'], {
+                cwd: fixture,
+                encoding: 'utf8',
+                env: { ...process.env, CI: 'true' },
+            });
+            expect(unstaged.status).not.toBe(0);
+            expect(unstaged.stderr).toContain('unstaged:');
+            expect(unstaged.stderr).toContain('M\ttracked.txt');
+
+            run(fixture, 'git', ['checkout', '--', 'tracked.txt']);
+            fs.writeFileSync(path.join(fixture, 'tracked.txt'), 'staged change\n');
+            run(fixture, 'git', ['add', 'tracked.txt']);
+            const staged = spawnSync(process.execPath, ['scripts/build-dist.mjs'], {
+                cwd: fixture,
+                encoding: 'utf8',
+                env: { ...process.env, CI: 'true' },
+            });
+            expect(staged.status).not.toBe(0);
+            expect(staged.stderr).toContain('staged:');
+            expect(staged.stderr).toContain('M\ttracked.txt');
+
+            run(fixture, 'git', ['reset', '-q', 'HEAD', '--', 'tracked.txt']);
+            run(fixture, 'git', ['checkout', '--', 'tracked.txt']);
             fs.writeFileSync(path.join(fixture, 'genuinely-dirty.txt'), 'dirty\n');
             const localEnv = { ...process.env, CI: '', GITHUB_ACTIONS: '' };
             const dirtyId = buildIdFrom(run(
@@ -55,8 +105,10 @@ describe('static distribution build identity', () => {
             });
             expect(blocked.status).not.toBe(0);
             expect(blocked.stderr).toContain('Refusing CI distribution build from a dirty Git checkout:');
-            expect(blocked.stderr).toContain('genuinely-dirty.txt');
+            expect(blocked.stderr).toContain('untracked:');
+            expect(blocked.stderr).toContain('? genuinely-dirty.txt');
 
+            fs.rmSync(path.join(fixture, 'genuinely-dirty.txt'));
             fs.renameSync(path.join(fixture, '.git'), path.join(fixture, '.git-unavailable'));
             const statusUnavailable = spawnSync(process.execPath, ['scripts/build-dist.mjs'], {
                 cwd: fixture,


### PR DESCRIPTION
Canonicalize `src-tauri/Cargo.toml` as LF and make build cleanliness content-aware while preserving fail-closed CI behavior.\n\nCandidate tree: `0d64a63e40bdfb3754f173689563197d9c6068c3`\n\nFocused validation: build-dist unit tests 2/2; diff-check passed.