### PR TITLE
docs: refine file-opening guidance

### DIFF
--- a/web/public/.well-known/agents.md
+++ b/web/public/.well-known/agents.md
@@ -15,7 +15,7 @@
 - Each image property uses one full-width select containing every embedded raster asset, `Open file…`, and `Clear`; the external file input is hidden, with no separate action buttons and standalone export parity.
 - Runtime 2.39.2 is the safe default. Web 2.40.0 / runtime-v0.1.271 has a confirmed nested-image double-offset in both renderers and is a warned explicit opt-in.
 - Other key surfaces include a 36-tool MCP bridge, event and script consoles, applied-editor-aware generated snippets, overflow-safe auto-margin canvas centering, styled fixed-canvas scrollbars, and standalone HTML export.
-- macOS .riv declarations support both current and legacy RAV identifiers, include the dedicated document icon resource, and register RAV as a Viewer without forcing a default-app change.
+- macOS .riv declarations support the official Rive UTI and the legacy RAV compatibility UTI, include the dedicated document icon resource, and register RAV as a Viewer without forcing a default-app change.
 - Windows NSIS and MSI packages contain a dedicated multi-resolution .riv icon with upgrade-aware registration and uninstall cleanup; this corrects the original draft's executable-icon registration.
 - Primary maintainers: IVG Design.
 

--- a/web/public/.well-known/llms.txt
+++ b/web/public/.well-known/llms.txt
@@ -24,7 +24,7 @@ RAV is a standalone desktop app for inspecting, debugging, and testing Rive (.ri
 - Transparency mode: https://forge.mograph.life/apps/rav/docs#transparency-mode
 - Standalone export: https://forge.mograph.life/apps/rav/docs#standalone-export
 - Applied editor config and lifecycle callbacks are preserved and executed in standalone exports: https://forge.mograph.life/apps/rav/docs/script-editor
-- macOS .riv declarations cover current and legacy RAV identifiers, include the dedicated document icon resource, and register RAV as a Viewer without default takeover: https://forge.mograph.life/apps/rav/docs/opening-files
+- macOS .riv declarations cover the official Rive UTI and legacy RAV compatibility UTI, include the dedicated document icon resource, and register RAV as a Viewer without default takeover: https://forge.mograph.life/apps/rav/docs/opening-files
 - Windows NSIS and MSI packages ship a dedicated multi-resolution .riv icon; installs and updates own the matching document-icon value, while uninstall cleanup preserves the association that preceded RAV: https://forge.mograph.life/apps/rav/docs/opening-files
 - RAV defaults to runtime 2.39.2 because 2.40.0 has a confirmed nested-image double-offset in both Canvas and WebGL2; Latest/2.40.0 remain warned explicit opt-ins: https://forge.mograph.life/apps/rav/docs/configuration
 - Fixed canvases use overflow-safe auto margins to stay centered while they fit and preserve authored-origin scrolling when oversized: https://forge.mograph.life/apps/rav/docs/ui-layout

--- a/web/public/agents.md
+++ b/web/public/agents.md
@@ -15,7 +15,7 @@
 - Each image property uses one full-width select containing every embedded raster asset, `Open file…`, and `Clear`; the external file input is hidden, with no separate action buttons and standalone export parity.
 - Runtime 2.39.2 is the safe default. Web 2.40.0 / runtime-v0.1.271 has a confirmed nested-image double-offset in both renderers and is a warned explicit opt-in.
 - Other key surfaces include a 36-tool MCP bridge, event and script consoles, applied-editor-aware generated snippets, overflow-safe auto-margin canvas centering, styled fixed-canvas scrollbars, and standalone HTML export.
-- macOS .riv declarations support both current and legacy RAV identifiers, include the dedicated document icon resource, and register RAV as a Viewer without forcing a default-app change.
+- macOS .riv declarations support the official Rive UTI and the legacy RAV compatibility UTI, include the dedicated document icon resource, and register RAV as a Viewer without forcing a default-app change.
 - Windows NSIS and MSI packages contain a dedicated multi-resolution .riv icon with upgrade-aware registration and uninstall cleanup; this corrects the original draft's executable-icon registration.
 - Primary maintainers: IVG Design.
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -24,7 +24,7 @@ RAV is a standalone desktop app for inspecting, debugging, and testing Rive (.ri
 - Transparency mode: https://forge.mograph.life/apps/rav/docs#transparency-mode
 - Standalone export: https://forge.mograph.life/apps/rav/docs#standalone-export
 - Applied editor config and lifecycle callbacks are preserved and executed in standalone exports: https://forge.mograph.life/apps/rav/docs/script-editor
-- macOS .riv declarations cover current and legacy RAV identifiers, include the dedicated document icon resource, and register RAV as a Viewer without default takeover: https://forge.mograph.life/apps/rav/docs/opening-files
+- macOS .riv declarations cover the official Rive UTI and legacy RAV compatibility UTI, include the dedicated document icon resource, and register RAV as a Viewer without default takeover: https://forge.mograph.life/apps/rav/docs/opening-files
 - Windows NSIS and MSI packages ship a dedicated multi-resolution .riv icon; installs and updates own the matching document-icon value, while uninstall cleanup preserves the association that preceded RAV: https://forge.mograph.life/apps/rav/docs/opening-files
 - RAV defaults to runtime 2.39.2 because 2.40.0 has a confirmed nested-image double-offset in both Canvas and WebGL2; Latest/2.40.0 remain warned explicit opt-ins: https://forge.mograph.life/apps/rav/docs/configuration
 - Fixed canvases use overflow-safe auto margins to stay centered while they fit and preserve authored-origin scrolling when oversized: https://forge.mograph.life/apps/rav/docs/ui-layout

--- a/web/src/app/docs/troubleshooting/page.tsx
+++ b/web/src/app/docs/troubleshooting/page.tsx
@@ -10,7 +10,7 @@ export default function Troubleshooting() {
         <li>Verify the file is a valid <code>.riv</code> file (not a <code>.rev</code> project file)</li>
         <li>Check the event console for error messages</li>
         <li>Try switching between Canvas and WebGL2 renderers</li>
-        <li>Ensure the file isn&apos;t corrupted &mdash; try opening it in the Rive Editor first</li>
+        <li>Ensure the file isn&apos;t corrupted &mdash; re-export it from the source project or obtain a fresh <code>.riv</code> export</li>
       </ul>
 
       <h2>Configuration won&apos;t apply</h2>
@@ -44,7 +44,7 @@ export default function Troubleshooting() {
 
       <h2>The Windows .riv icon did not change</h2>
       <ul>
-        <li>The original 2.4.3 draft pointed <code>Rive File\DefaultIcon</code> at the application executable; changing the default app could not produce the supplied document artwork</li>
+        <li>Older Windows installs may point <code>Rive File\DefaultIcon</code> at the application executable instead of the dedicated document icon</li>
         <li>The 2.4.3 release bundles <code>RiveFileIcon.ico</code>, rewrites that value during NSIS install/update, and notifies Explorer</li>
         <li>Verify the installed icon path exists before clearing Explorer&apos;s icon cache</li>
       </ul>


### PR DESCRIPTION
Corrects compiled .riv troubleshooting guidance, removes internal draft wording, and names the official Rive and legacy RAV compatibility UTIs precisely.\n\nValidation: website lint, mirror parity, stale-reference scan, and diff checks pass.