### PR TITLE
docs(web): polish 2.5.3 release copy

### DIFF
--- a/web/src/app/docs/mcp/page.tsx
+++ b/web/src/app/docs/mcp/page.tsx
@@ -117,7 +117,7 @@ export default function McpIntegration() {
 
       <h2>GLOBAL VM in RAV</h2>
       <p>
-        When a file provides globals, the sidebar labels their collection <strong>GLOBAL VM</strong>
+        When a file provides globals, the sidebar labels their collection <strong>GLOBAL VM</strong>{" "}
         above <strong>ROOT VM</strong>. <strong>GLOBAL VM</strong> starts collapsed, and each named
         global has its own independent expandable tree; opening one does not expand another.
       </p>

--- a/web/src/app/docs/updates/page.tsx
+++ b/web/src/app/docs/updates/page.tsx
@@ -39,8 +39,8 @@ export default function Updates() {
       <h2>Release Feed</h2>
       <p>
         The updater only surfaces a new version after the full multi-platform release
-        completes, all native-signing and artifact-parity checks pass, and the merged
-        <code>latest.json</code> feed is published. Draft releases are ignored by the
+        completes, all native-signing and artifact-parity checks pass, and the merged{" "}
+        <code>latest.json</code> feed is published. Draft releases are ignored by the{" "}
         <code>releases/latest</code> endpoint, so a partially complete release cannot
         advance installed clients.
       </p>


### PR DESCRIPTION
## Summary
- preserve visible spacing around inline MCP/update code labels
- prepare a fresh post-publication website build so the changelog marks 2.5.3 as Latest public

## Validation
- `npm run lint` (web)
- clean-cache `npm run build` (web)
- generated changelog contains `v2.5.3` + `Latest public` and no release-candidate badge
- generated structured data reports `softwareVersion: 2.5.3`